### PR TITLE
[M5-AUDIT] refactor/crypto-encrypted-redb-wrapper

### DIFF
--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -6,6 +6,7 @@ pub mod file;
 pub mod keychain;
 pub mod keys;
 pub mod reencrypt;
+pub mod working_file;
 
 pub use error::CryptoError;
 pub use keys::{MasterKey, DEK};

--- a/crates/crypto/src/working_file.rs
+++ b/crates/crypto/src/working_file.rs
@@ -1,0 +1,160 @@
+//! Helpers for encrypted-file-backed working copies.
+//!
+//! Several Sena subsystems (Soul, Memory) follow the same pattern:
+//!
+//! 1. **Open:** Decrypt a persistent `.enc` file to a temporary working copy.
+//! 2. **Flush:** Encrypt the working copy back to the persistent path.
+//! 3. **Close:** Flush + remove the temporary working copy.
+//!
+//! This module extracts those primitives so they are defined once.
+
+use std::path::Path;
+
+use crate::error::CryptoError;
+use crate::keys::MasterKey;
+
+/// Remove a stale working file/directory left over from a previous crash.
+///
+/// Returns `Ok(true)` if something was removed, `Ok(false)` if the path
+/// did not exist.
+pub fn clean_stale_working(path: &Path) -> Result<bool, CryptoError> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    if path.is_dir() {
+        std::fs::remove_dir_all(path).map_err(CryptoError::IoError)?;
+    } else {
+        std::fs::remove_file(path).map_err(CryptoError::IoError)?;
+    }
+    Ok(true)
+}
+
+/// Decrypt an encrypted file to a working path.
+///
+/// If `encrypted_path` does not exist, returns `Ok(false)` and the working
+/// path is left untouched. If it does exist, the decrypted contents are
+/// written to `working_path` and `Ok(true)` is returned.
+pub fn decrypt_to_working(
+    encrypted_path: &Path,
+    working_path: &Path,
+    master_key: &MasterKey,
+) -> Result<bool, CryptoError> {
+    if !encrypted_path.exists() {
+        return Ok(false);
+    }
+    let plaintext = crate::file::read_encrypted_file(encrypted_path, master_key)?;
+    std::fs::write(working_path, &plaintext).map_err(CryptoError::IoError)?;
+    Ok(true)
+}
+
+/// Encrypt a working file back to the persistent encrypted path.
+pub fn encrypt_from_working(
+    working_path: &Path,
+    encrypted_path: &Path,
+    master_key: &MasterKey,
+) -> Result<(), CryptoError> {
+    let plaintext = std::fs::read(working_path).map_err(CryptoError::IoError)?;
+    crate::file::write_encrypted_file(encrypted_path, &plaintext, master_key)
+}
+
+/// Brief sleep to let Windows release file locks before cleanup.
+///
+/// On non-Windows platforms this is a no-op. The 10 ms pause is a
+/// pragmatic workaround for Windows mmap handle release timing.
+pub fn wait_for_file_lock_release() {
+    #[cfg(target_os = "windows")]
+    std::thread::sleep(std::time::Duration::from_millis(10));
+}
+
+/// Clean up a working file or directory after encryption.
+///
+/// Calls [`wait_for_file_lock_release`] first, then removes the path.
+pub fn cleanup_working(path: &Path) {
+    wait_for_file_lock_release();
+    if path.is_dir() {
+        let _ = std::fs::remove_dir_all(path);
+    } else {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_master_key() -> MasterKey {
+        MasterKey::from_bytes([42u8; 32])
+    }
+
+    #[test]
+    fn round_trip_decrypt_encrypt() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let enc_path = dir.path().join("data.enc");
+        let work_path = dir.path().join("data.working");
+
+        let original = b"hello encrypted working file";
+
+        // Write encrypted file via existing primitive
+        crate::file::write_encrypted_file(&enc_path, original, &test_master_key())
+            .expect("write");
+
+        // Decrypt to working
+        let existed = decrypt_to_working(&enc_path, &work_path, &test_master_key())
+            .expect("decrypt_to_working");
+        assert!(existed);
+        assert_eq!(std::fs::read(&work_path).unwrap(), original);
+
+        // Modify working file
+        std::fs::write(&work_path, b"modified content").unwrap();
+
+        // Encrypt back
+        encrypt_from_working(&work_path, &enc_path, &test_master_key())
+            .expect("encrypt_from_working");
+
+        // Verify round-trip
+        let recovered =
+            crate::file::read_encrypted_file(&enc_path, &test_master_key()).expect("read back");
+        assert_eq!(recovered, b"modified content");
+
+        // Cleanup
+        cleanup_working(&work_path);
+        assert!(!work_path.exists());
+    }
+
+    #[test]
+    fn decrypt_nonexistent_returns_false() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let existed = decrypt_to_working(
+            &dir.path().join("nope.enc"),
+            &dir.path().join("nope.working"),
+            &test_master_key(),
+        )
+        .expect("should succeed");
+        assert!(!existed);
+    }
+
+    #[test]
+    fn clean_stale_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("stale.working");
+        std::fs::write(&path, b"stale").unwrap();
+        assert!(clean_stale_working(&path).expect("clean"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn clean_stale_dir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("stale_dir");
+        std::fs::create_dir_all(&path).unwrap();
+        std::fs::write(path.join("file.txt"), b"data").unwrap();
+        assert!(clean_stale_working(&path).expect("clean"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn clean_nonexistent_returns_false() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(!clean_stale_working(&dir.path().join("nope")).expect("clean"));
+    }
+}

--- a/crates/memory/src/encrypted_store.rs
+++ b/crates/memory/src/encrypted_store.rs
@@ -1,5 +1,6 @@
 use crate::error::MemoryError;
 use crypto::MasterKey;
+use crypto::working_file;
 use std::path::{Path, PathBuf};
 
 /// Manages encrypted storage for ech0's persistent files.
@@ -37,9 +38,7 @@ impl EncryptedStore {
         std::fs::create_dir_all(encrypted_dir)?;
 
         // Clean up any stale working directory from a previous crash
-        if working_dir.exists() {
-            std::fs::remove_dir_all(&working_dir)?;
-        }
+        working_file::clean_stale_working(&working_dir)?;
         std::fs::create_dir_all(&working_dir)?;
 
         // Decrypt all .enc files to the working directory
@@ -48,7 +47,6 @@ impl EncryptedStore {
             let path = entry.path();
 
             if path.extension().and_then(|e| e.to_str()) == Some("enc") {
-                let plaintext = crypto::file::read_encrypted_file(&path, master_key)?;
                 let stem = path
                     .file_stem()
                     .ok_or_else(|| MemoryError::Store("invalid encrypted filename".to_string()))?;
@@ -61,8 +59,8 @@ impl EncryptedStore {
                     ));
                 }
 
-                let working_file = working_dir.join(stem);
-                std::fs::write(&working_file, &plaintext)?;
+                let working_file_path = working_dir.join(stem);
+                working_file::decrypt_to_working(&path, &working_file_path, master_key)?;
             }
         }
 
@@ -94,10 +92,7 @@ impl EncryptedStore {
     pub fn close(mut self) -> Result<(), MemoryError> {
         self.encrypt_working_files()?;
 
-        // Give Windows a moment to release file locks before removing directory
-        std::thread::sleep(std::time::Duration::from_millis(10));
-
-        let _ = std::fs::remove_dir_all(&self.working_dir);
+        working_file::cleanup_working(&self.working_dir);
         self.closed = true;
         Ok(())
     }
@@ -124,8 +119,7 @@ impl EncryptedStore {
             enc_name.push(".enc");
             let enc_path = self.encrypted_dir.join(enc_name);
 
-            let plaintext = std::fs::read(&path)?;
-            crypto::file::write_encrypted_file(&enc_path, &plaintext, &self.master_key)?;
+            working_file::encrypt_from_working(&path, &enc_path, &self.master_key)?;
         }
         Ok(())
     }
@@ -139,7 +133,7 @@ impl Drop for EncryptedStore {
 
         // Best-effort encrypt on drop if close() wasn't called
         let _ = self.encrypt_working_files();
-        let _ = std::fs::remove_dir_all(&self.working_dir);
+        working_file::cleanup_working(&self.working_dir);
     }
 }
 

--- a/crates/soul/src/encrypted_db.rs
+++ b/crates/soul/src/encrypted_db.rs
@@ -1,5 +1,6 @@
 use crate::error::SoulError;
 use crypto::MasterKey;
+use crypto::working_file;
 use std::path::{Path, PathBuf};
 
 #[cfg(test)]
@@ -35,14 +36,11 @@ impl EncryptedDb {
 
         // If a stale working file exists from a previous crash, remove it.
         // We always trust the encrypted file as the source of truth.
-        if working_path.exists() {
-            std::fs::remove_file(&working_path)?;
-        }
+        working_file::clean_stale_working(&working_path)?;
 
         let db = if encrypted_path.exists() {
             // Decrypt existing database to working path
-            let plaintext = crypto::file::read_encrypted_file(encrypted_path, master_key)?;
-            std::fs::write(&working_path, &plaintext)?;
+            working_file::decrypt_to_working(encrypted_path, &working_path, master_key)?;
 
             // Try to open the database
             match redb::Database::open(&working_path) {
@@ -114,9 +112,12 @@ impl EncryptedDb {
         // Close the database to release the file handle (mmap)
         self.db.take();
 
-        // Read the working file and encrypt to persistent location
-        let plaintext = std::fs::read(&self.working_path)?;
-        crypto::file::write_encrypted_file(&self.encrypted_path, &plaintext, &self.master_key)?;
+        // Encrypt working file to persistent location
+        working_file::encrypt_from_working(
+            &self.working_path,
+            &self.encrypted_path,
+            &self.master_key,
+        )?;
 
         // Reopen the database for continued use
         self.db = Some(redb::Database::open(&self.working_path)?);
@@ -131,13 +132,14 @@ impl EncryptedDb {
         // Drop the database to release the file handle and all locks
         drop(self.db.take());
 
-        // On Windows, file locks may not release immediately. Give a brief moment
-        // for the OS to release the lock before we try to read the file.
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        working_file::wait_for_file_lock_release();
 
-        // Read and encrypt to persistent location
-        let plaintext = std::fs::read(&self.working_path)?;
-        crypto::file::write_encrypted_file(&self.encrypted_path, &plaintext, &self.master_key)?;
+        // Encrypt working file to persistent location
+        working_file::encrypt_from_working(
+            &self.working_path,
+            &self.encrypted_path,
+            &self.master_key,
+        )?;
 
         // Clean up working file
         let _ = std::fs::remove_file(&self.working_path);
@@ -163,13 +165,11 @@ impl Drop for EncryptedDb {
 
         // Database wasn't properly closed via close() — best-effort encrypt.
         self.db.take();
-        if let Ok(plaintext) = std::fs::read(&self.working_path) {
-            let _ = crypto::file::write_encrypted_file(
-                &self.encrypted_path,
-                &plaintext,
-                &self.master_key,
-            );
-        }
+        let _ = working_file::encrypt_from_working(
+            &self.working_path,
+            &self.encrypted_path,
+            &self.master_key,
+        );
         let _ = std::fs::remove_file(&self.working_path);
     }
 }


### PR DESCRIPTION
## Summary
Extract crypto::working_file shared module to eliminate DRY violation between soul/encrypted_db.rs and memory/encrypted_store.rs

## Units completed
Closes #6

## Review status
| Reviewer | Verdict |
|---|---|
| arch-guard | APPROVED |
| sec-auditor | APPROVED |
| reviewer | APPROVED |

## Test status
| Check | Result |
|---|---|
| \cargo build --workspace\ | passing |
| \cargo test --workspace\ | passing (489 tests) |
| \cargo clippy --workspace -- -D warnings\ | clean |
| \cargo fmt --check\ | clean |

---
*Auto-generated by git-master. Targets: \dev\. Never merges to \main\.*