### PR TITLE
[M5-AUDIT] fix/platform-secure-clipboard-hash

### DIFF
--- a/crates/platform/src/linux.rs
+++ b/crates/platform/src/linux.rs
@@ -36,7 +36,6 @@ impl PlatformAdapter for LinuxPlatform {
     }
 
     fn clipboard_digest(&self) -> Option<ClipboardDigest> {
-        use std::hash::{Hash, Hasher};
         use std::time::Instant;
 
         let text = arboard::Clipboard::new()
@@ -48,9 +47,9 @@ impl PlatformAdapter for LinuxPlatform {
         }
 
         let char_count = text.chars().count();
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        text.hash(&mut hasher);
-        let digest_hex = format!("{:016x}", hasher.finish());
+        use sha2::{Digest, Sha256};
+        let digest = Sha256::digest(text.as_bytes());
+        let digest_hex = format!("{:x}", digest);
 
         Some(ClipboardDigest {
             digest: Some(digest_hex),

--- a/crates/platform/src/macos.rs
+++ b/crates/platform/src/macos.rs
@@ -36,7 +36,6 @@ impl PlatformAdapter for MacOSPlatform {
     }
 
     fn clipboard_digest(&self) -> Option<ClipboardDigest> {
-        use std::hash::{Hash, Hasher};
         use std::time::Instant;
 
         let text = arboard::Clipboard::new()
@@ -48,9 +47,9 @@ impl PlatformAdapter for MacOSPlatform {
         }
 
         let char_count = text.chars().count();
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        text.hash(&mut hasher);
-        let digest_hex = format!("{:016x}", hasher.finish());
+        use sha2::{Digest, Sha256};
+        let digest = Sha256::digest(text.as_bytes());
+        let digest_hex = format!("{:x}", digest);
 
         Some(ClipboardDigest {
             digest: Some(digest_hex),

--- a/crates/platform/src/windows.rs
+++ b/crates/platform/src/windows.rs
@@ -1,8 +1,6 @@
 //! Windows platform adapter implementation.
 
 #[cfg(target_os = "windows")]
-use std::hash::{Hash, Hasher};
-#[cfg(target_os = "windows")]
 use std::time::Instant;
 
 #[cfg(target_os = "windows")]
@@ -197,9 +195,9 @@ impl PlatformAdapter for WindowsPlatform {
         let char_count = text.chars().count();
 
         // Hash the content â€” never store raw clipboard text.
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        text.hash(&mut hasher);
-        let digest_hex = format!("{:016x}", hasher.finish());
+        use sha2::{Digest, Sha256};
+        let digest = Sha256::digest(text.as_bytes());
+        let digest_hex = format!("{:x}", digest);
 
         Some(ClipboardDigest {
             digest: Some(digest_hex),


### PR DESCRIPTION
## Summary
Replace insecure DefaultHasher with SHA-256 for clipboard digest in platform crate (all 3 OS implementations)

## Units completed
Closes #3

## Review status
| Reviewer | Verdict |
|---|---|
| arch-guard | APPROVED |
| sec-auditor | APPROVED (H1-CRITICAL fixed) |
| reviewer | APPROVED |

## Test status
| Check | Result |
|---|---|
| \cargo build --workspace\ | passing |
| \cargo test --workspace\ | passing (489 tests) |
| \cargo clippy --workspace -- -D warnings\ | clean |
| \cargo fmt --check\ | clean |

---
*Auto-generated by git-master. Targets: \dev\. Never merges to \main\.*