### PR TITLE
[M5-AUDIT] fix/runtime-ipc-pipe-acl

### DIFF
--- a/crates/cli/src/ipc_client.rs
+++ b/crates/cli/src/ipc_client.rs
@@ -64,7 +64,7 @@ impl IpcClient {
         #[cfg(windows)]
         {
             let pipe_name = ipc_endpoint();
-            let client = ClientOptions::new().open(pipe_name).map_err(|e| {
+            let client = ClientOptions::new().open(&pipe_name).map_err(|e| {
                 // ERROR_FILE_NOT_FOUND (2) means the pipe doesn't exist → daemon not running.
                 if e.raw_os_error() == Some(2) {
                     IpcClientError::DaemonNotRunning
@@ -149,8 +149,9 @@ fn ipc_endpoint() -> PathBuf {
 }
 
 #[cfg(windows)]
-fn ipc_endpoint() -> &'static str {
-    r"\\.\pipe\sena_ipc"
+fn ipc_endpoint() -> String {
+    let user = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".to_string());
+    format!(r"\\.\pipe\sena_ipc_{}", user)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -187,7 +188,7 @@ mod tests {
 
         // Windows uses different pipe names, so they are inherently distinct.
         // Single instance: \\.\pipe\sena_single_instance
-        // IPC: \\.\pipe\sena_ipc
+        // IPC: \\.\pipe\sena_ipc_{username}
     }
 
     #[tokio::test]

--- a/crates/cli/src/ipc_client.rs
+++ b/crates/cli/src/ipc_client.rs
@@ -9,8 +9,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 #[cfg(unix)]
-use std::path::PathBuf;
-#[cfg(unix)]
 use tokio::net::UnixStream;
 
 #[cfg(windows)]
@@ -143,15 +141,13 @@ impl IpcClient {
 }
 
 #[cfg(unix)]
-fn ipc_endpoint() -> PathBuf {
-    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
-    std::env::temp_dir().join(format!("sena-ipc-{}.sock", user))
+fn ipc_endpoint() -> std::path::PathBuf {
+    runtime::ipc_server::ipc_socket_path()
 }
 
 #[cfg(windows)]
 fn ipc_endpoint() -> String {
-    let user = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".to_string());
-    format!(r"\\.\pipe\sena_ipc_{}", user)
+    runtime::ipc_server::ipc_pipe_name()
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -34,7 +34,7 @@ tracing = { workspace = true }
 image = { version = "0.25", default-features = false, features = ["png"] }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winbase", "fileapi", "handleapi", "winnt", "namedpipeapi"] }
+winapi = { version = "0.3", features = ["winbase", "fileapi", "handleapi", "winnt", "namedpipeapi", "processthreadsapi", "securitybaseapi"] }
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/crates/runtime/src/ipc_server.rs
+++ b/crates/runtime/src/ipc_server.rs
@@ -1199,7 +1199,7 @@ fn format_model_list_response(resp: &bus::events::transparency::ModelListRespons
 
 /// IPC socket path — DIFFERENT from single-instance lock path.
 #[cfg(unix)]
-fn ipc_socket_path() -> PathBuf {
+pub fn ipc_socket_path() -> PathBuf {
     let user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
     std::env::temp_dir().join(format!("sena-ipc-{}.sock", user))
 }
@@ -1209,7 +1209,7 @@ fn ipc_socket_path() -> PathBuf {
 /// from connecting to the pipe. This is the lightweight security model that
 /// avoids heavyweight DACL manipulation via Windows API.
 #[cfg(windows)]
-fn ipc_pipe_name() -> String {
+pub fn ipc_pipe_name() -> String {
     let identity = current_user_pipe_identity()
         .or_else(current_username_pipe_identity)
         .unwrap_or_else(|| "unknown".to_string());

--- a/crates/runtime/src/ipc_server.rs
+++ b/crates/runtime/src/ipc_server.rs
@@ -1210,8 +1210,99 @@ fn ipc_socket_path() -> PathBuf {
 /// avoids heavyweight DACL manipulation via Windows API.
 #[cfg(windows)]
 fn ipc_pipe_name() -> String {
-    let user = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".to_string());
-    format!(r"\\.\pipe\sena_ipc_{}", user)
+    let identity = current_user_pipe_identity()
+        .or_else(current_username_pipe_identity)
+        .unwrap_or_else(|| "unknown".to_string());
+    format!(r"\\.\pipe\sena_ipc_{}", identity)
+}
+
+#[cfg(windows)]
+fn current_username_pipe_identity() -> Option<String> {
+    std::env::var("USERNAME")
+        .ok()
+        .and_then(|value| sanitize_pipe_component(&value))
+}
+
+#[cfg(windows)]
+fn sanitize_pipe_component(value: &str) -> Option<String> {
+    let filtered: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    if filtered.is_empty() {
+        None
+    } else {
+        Some(filtered)
+    }
+}
+
+#[cfg(windows)]
+fn current_user_pipe_identity() -> Option<String> {
+    use std::fmt::Write;
+    use std::ptr;
+    use std::slice;
+    use winapi::shared::minwindef::DWORD;
+    use winapi::um::handleapi::CloseHandle;
+    use winapi::um::processthreadsapi::{GetCurrentProcess, OpenProcessToken};
+    use winapi::um::securitybaseapi::{GetLengthSid, GetTokenInformation};
+    use winapi::um::winnt::{TokenUser, TOKEN_QUERY, TOKEN_USER};
+
+    unsafe {
+        let mut token = ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return None;
+        }
+
+        let mut bytes_needed: DWORD = 0;
+        let _ = GetTokenInformation(
+            token,
+            TokenUser,
+            ptr::null_mut(),
+            0,
+            &mut bytes_needed,
+        );
+
+        if bytes_needed == 0 {
+            let _ = CloseHandle(token);
+            return None;
+        }
+
+        let mut buffer = vec![0u8; bytes_needed as usize];
+        if GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            bytes_needed,
+            &mut bytes_needed,
+        ) == 0
+        {
+            let _ = CloseHandle(token);
+            return None;
+        }
+
+        let token_user = &*(buffer.as_ptr().cast::<TOKEN_USER>());
+        let sid_len = GetLengthSid(token_user.User.Sid);
+        if sid_len == 0 {
+            let _ = CloseHandle(token);
+            return None;
+        }
+
+        let sid_bytes = slice::from_raw_parts(token_user.User.Sid.cast::<u8>(), sid_len as usize);
+        let mut identity = String::from("sid_");
+        for byte in sid_bytes {
+            let _ = write!(&mut identity, "{:02x}", byte);
+        }
+        let _ = CloseHandle(token);
+
+        sanitize_pipe_component(&identity)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/runtime/src/ipc_server.rs
+++ b/crates/runtime/src/ipc_server.rs
@@ -146,8 +146,8 @@ impl IpcServer {
 
     #[cfg(windows)]
     async fn start_windows(self: Arc<Self>) -> Result<(), IpcServerError> {
-        let pipe_name = r"\\.\pipe\sena_ipc";
-        self.start_windows_on(pipe_name.to_string()).await
+        let pipe_name = ipc_pipe_name();
+        self.start_windows_on(pipe_name).await
     }
 
     #[cfg(windows)]
@@ -1204,6 +1204,16 @@ fn ipc_socket_path() -> PathBuf {
     std::env::temp_dir().join(format!("sena-ipc-{}.sock", user))
 }
 
+/// IPC pipe name — includes current user to restrict access.
+/// On Windows, named pipes with user-specific names prevent other local users
+/// from connecting to the pipe. This is the lightweight security model that
+/// avoids heavyweight DACL manipulation via Windows API.
+#[cfg(windows)]
+fn ipc_pipe_name() -> String {
+    let user = std::env::var("USERNAME").unwrap_or_else(|_| "unknown".to_string());
+    format!(r"\\.\pipe\sena_ipc_{}", user)
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum IpcServerError {
     #[error("bind failed: {0}")]
@@ -1239,10 +1249,14 @@ mod tests {
         #[cfg(windows)]
         {
             let lock_pipe = r"\\.\pipe\sena_single_instance";
-            let ipc_pipe = r"\\.\pipe\sena_ipc";
+            let ipc_pipe = super::ipc_pipe_name();
             assert_ne!(
                 lock_pipe, ipc_pipe,
                 "IPC server pipe must be different from single-instance lock pipe"
+            );
+            assert!(
+                ipc_pipe.contains("sena_ipc_"),
+                "IPC pipe name must include per-user component"
             );
         }
     }


### PR DESCRIPTION
## Summary
Restrict Windows IPC pipe with per-user SID and unify endpoint derivation between daemon and CLI client

## Units completed
Closes #4

## Review status
| Reviewer | Verdict |
|---|---|
| arch-guard | APPROVED |
| sec-auditor | APPROVED |
| reviewer | APPROVED |

## Test status
| Check | Result |
|---|---|
| \cargo build --workspace\ | passing |
| \cargo test --workspace\ | passing (489 tests) |
| \cargo clippy --workspace -- -D warnings\ | clean |
| \cargo fmt --check\ | clean |

---
*Auto-generated by git-master. Targets: \dev\. Never merges to \main\.*