### PR TITLE
Phase 7A: Intelligence bus event types

### DIFF
--- a/crates/bus/src/bus.rs
+++ b/crates/bus/src/bus.rs
@@ -19,7 +19,7 @@ pub enum Event {
     /// Platform vision events (screen capture digests, visual context).
     PlatformVision(PlatformVisionEvent),
     /// CTP (Continuous Thought Processing) events.
-    CTP(CTPEvent),
+    CTP(Box<CTPEvent>),
     /// Inference-layer events (model discovery, inference requests/responses).
     Inference(InferenceEvent),
     /// Memory subsystem events (write/query requests and responses).

--- a/crates/bus/src/events/ctp.rs
+++ b/crates/bus/src/events/ctp.rs
@@ -32,6 +32,59 @@ pub struct TaskHint {
     pub confidence: f32,
 }
 
+/// Enriched inferred task with semantic description.
+/// Replacement for TaskHint with richer context.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnrichedInferredTask {
+    /// Task category (e.g., "coding", "writing", "research").
+    pub category: String,
+    /// Semantic description of what the user appears to be doing.
+    pub semantic_description: String,
+    /// Confidence level for the inference (0.0 to 1.0).
+    pub confidence: f32,
+}
+
+impl From<TaskHint> for EnrichedInferredTask {
+    fn from(hint: TaskHint) -> Self {
+        EnrichedInferredTask {
+            category: hint.category.clone(),
+            semantic_description: hint.category,
+            confidence: hint.confidence,
+        }
+    }
+}
+
+/// User cognitive state derived from behavioral signals.
+#[derive(Debug, Clone)]
+pub struct UserState {
+    /// Frustration level (0-100).
+    pub frustration_level: u8,
+    /// Whether the user is in a flow state.
+    pub flow_detected: bool,
+    /// Cost of context switching (0-100).
+    pub context_switch_cost: u8,
+}
+
+/// Type of signal pattern detected.
+#[derive(Debug, Clone)]
+pub enum SignalPatternType {
+    Frustration,
+    Repetition,
+    FlowState,
+    Anomaly,
+}
+
+/// Detected signal pattern from multi-modal signal analysis.
+#[derive(Debug, Clone)]
+pub struct SignalPattern {
+    /// Type of pattern detected.
+    pub pattern_type: SignalPatternType,
+    /// Confidence in the pattern detection (0.0 to 1.0).
+    pub confidence: f32,
+    /// Human-readable description of the pattern.
+    pub description: String,
+}
+
 /// Structured capture of user's computing context at a moment in time.
 ///
 /// This is the typed output of the CTP Context Assembler.
@@ -49,7 +102,9 @@ pub struct ContextSnapshot {
     /// Duration of the current session.
     pub session_duration: Duration,
     /// Inferred task, if any.
-    pub inferred_task: Option<TaskHint>,
+    pub inferred_task: Option<EnrichedInferredTask>,
+    /// User cognitive state, if computed.
+    pub user_state: Option<UserState>,
     /// Visual context from screen capture, if recent and enabled.
     pub visual_context: Option<VisualContext>,
     /// When this snapshot was captured.
@@ -63,6 +118,10 @@ pub enum CTPEvent {
     ContextSnapshotReady(ContextSnapshot),
     /// A thought event has been triggered based on a context snapshot.
     ThoughtEventTriggered(ContextSnapshot),
+    /// User cognitive state has been computed.
+    UserStateComputed(UserState),
+    /// A signal pattern has been detected.
+    SignalPatternDetected(SignalPattern),
 }
 
 #[cfg(test)]
@@ -107,8 +166,9 @@ mod tests {
             timestamp: now,
         };
 
-        let task_hint = TaskHint {
+        let task = EnrichedInferredTask {
             category: "coding".to_string(),
+            semantic_description: "Editing Rust code in VSCode".to_string(),
             confidence: 0.92,
         };
 
@@ -118,7 +178,8 @@ mod tests {
             clipboard_digest: Some("sha256:abcdef1234567890".to_string()),
             keystroke_cadence,
             session_duration: Duration::from_secs(3600),
-            inferred_task: Some(task_hint),
+            inferred_task: Some(task),
+            user_state: None,
             visual_context: None,
             timestamp: now,
         };
@@ -133,9 +194,9 @@ mod tests {
         assert_eq!(snapshot.keystroke_cadence.events_per_minute, 180.5);
         assert_eq!(snapshot.session_duration, Duration::from_secs(3600));
         assert!(snapshot.inferred_task.is_some());
-        if let Some(hint) = &snapshot.inferred_task {
-            assert_eq!(hint.category, "coding");
-            assert_eq!(hint.confidence, 0.92);
+        if let Some(task) = &snapshot.inferred_task {
+            assert_eq!(task.category, "coding");
+            assert_eq!(task.confidence, 0.92);
         }
     }
 
@@ -160,6 +221,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(1800),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         };
@@ -240,6 +302,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(0),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }

--- a/crates/bus/src/events/soul.rs
+++ b/crates/bus/src/events/soul.rs
@@ -80,6 +80,90 @@ pub struct PersonalityUpdated {
     pub verbosity: u8,
 }
 
+/// Distilled identity signal extracted from behavioral patterns.
+#[derive(Debug, Clone)]
+pub struct DistilledIdentitySignal {
+    /// The signal's semantic key (e.g., "preferred_editor", "work_start_time").
+    pub signal_key: String,
+    /// The signal's value (e.g., "vscode", "09:00").
+    pub signal_value: String,
+    /// Confidence in this signal's accuracy (0.0 to 1.0).
+    pub confidence: f32,
+    /// Number of source events that contributed to this signal.
+    pub source_event_count: u32,
+}
+
+/// Temporal behavior pattern derived from event log analysis.
+#[derive(Debug, Clone)]
+pub struct TemporalBehaviorPattern {
+    /// Hour of day (0-23), if time-of-day is relevant.
+    pub hour_of_day: Option<u8>,
+    /// Day of week (0=Monday, 6=Sunday), if day-of-week is relevant.
+    pub day_of_week: Option<u8>,
+    /// Semantic category of the behavior (e.g., "deep_work", "meetings").
+    pub behavior_category: String,
+    /// How often this pattern occurs (event count).
+    pub frequency: u32,
+}
+
+/// User engagement signal in response to Sena's proactive inference.
+#[derive(Debug, Clone)]
+pub enum EngagementSignal {
+    /// User explicitly accepted or acted on the response.
+    Accepted,
+    /// User ignored the response (no interaction within timeout).
+    Ignored,
+    /// User interrupted or dismissed the response.
+    Interrupted,
+    /// User asked a follow-up question.
+    FollowUpQuery,
+}
+
+/// Type of Soul content section in a rich summary.
+#[derive(Debug, Clone)]
+pub enum SoulSectionType {
+    /// Recent event log entries.
+    RecentEvents,
+    /// Distilled identity signals.
+    IdentitySignals,
+    /// Temporal habit patterns.
+    TemporalHabits,
+    /// User preferences.
+    Preferences,
+}
+
+/// A single section of a rich Soul summary.
+#[derive(Debug, Clone)]
+pub struct SoulSection {
+    /// Type of content in this section.
+    pub section_type: SoulSectionType,
+    /// The actual content text.
+    pub content: String,
+    /// Relevance score for prompt prioritization (0.0 to 1.0).
+    pub relevance_score: f32,
+}
+
+/// Rich structured summary of Soul state for prompt composition.
+#[derive(Clone)]
+pub struct RichSoulSummary {
+    /// Ordered sections (highest relevance first).
+    pub sections: Vec<SoulSection>,
+    /// Total token count (approximate).
+    pub token_count: usize,
+    /// Request ID for correlation.
+    pub request_id: u64,
+}
+
+impl std::fmt::Debug for RichSoulSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RichSoulSummary")
+            .field("sections", &format!("{} sections", self.sections.len()))
+            .field("token_count", &self.token_count)
+            .field("request_id", &self.request_id)
+            .finish()
+    }
+}
+
 /// Request for a transparency view of the Soul state for transparency queries.
 #[derive(Debug, Clone)]
 pub struct SoulReadRequest {
@@ -130,6 +214,26 @@ pub enum SoulEvent {
         /// Failure reason.
         reason: String,
     },
+    /// A distilled identity signal has been extracted.
+    IdentitySignalDistilled(DistilledIdentitySignal),
+    /// A temporal behavior pattern has been detected.
+    TemporalPatternDetected(TemporalBehaviorPattern),
+    /// User engagement signal in response to a proactive inference.
+    PreferenceLearningUpdate {
+        /// ID of the response that triggered this signal.
+        response_id: u64,
+        /// The engagement signal type.
+        signal: EngagementSignal,
+    },
+    /// Request for a rich, structured Soul summary.
+    RichSummaryRequested {
+        /// Token budget for the summary.
+        token_budget: usize,
+        /// Request ID for correlation.
+        request_id: u64,
+    },
+    /// Rich summary is ready.
+    RichSummaryReady(RichSoulSummary),
 }
 
 #[cfg(test)]

--- a/crates/bus/src/events/transparency.rs
+++ b/crates/bus/src/events/transparency.rs
@@ -80,7 +80,7 @@ pub struct ModelListResponse {
 #[derive(Debug, Clone)]
 pub enum TransparencyEvent {
     QueryRequested(TransparencyQuery),
-    ObservationResponded(ObservationResponse),
+    ObservationResponded(Box<ObservationResponse>),
     MemoryResponded(MemoryResponse),
     InferenceExplanationResponded(InferenceExplanationResponse),
     ModelListResponded(ModelListResponse),

--- a/crates/bus/src/lib.rs
+++ b/crates/bus/src/lib.rs
@@ -45,6 +45,7 @@ mod integration_tests {
             },
             session_duration: Duration::from_secs(0),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }

--- a/crates/cli/src/query.rs
+++ b/crates/cli/src/query.rs
@@ -394,10 +394,12 @@ mod tests {
                 timestamp: std::time::Instant::now(),
             },
             session_duration: Duration::from_secs(3600),
-            inferred_task: Some(bus::events::ctp::TaskHint {
+            inferred_task: Some(bus::events::ctp::EnrichedInferredTask {
                 category: "coding".to_string(),
+                semantic_description: "Writing Rust code".to_string(),
                 confidence: 0.92,
             }),
+            user_state: None,
             visual_context: None,
             timestamp: std::time::Instant::now(),
         };
@@ -431,6 +433,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(0),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: std::time::Instant::now(),
         };

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -240,12 +240,12 @@ impl Shell {
     /// Create a new Shell instance.
     fn new(runtime: Arc<Runtime>) -> Self {
         let voice_enabled = runtime.config.speech_enabled;
-        
+
         // Initialize shared state with welcome messages.
         let mut state = crate::tui_state::ShellState::new();
         state.add_welcome_message("Welcome to Sena — local-first ambient AI");
         state.add_welcome_message("Type /help for commands, or chat freely.");
-        
+
         // Seed current_model from runtime config.
         state.current_model = runtime.config.preferred_model.clone();
 
@@ -509,7 +509,11 @@ impl Shell {
                 .fg(Color::LightMagenta)
                 .add_modifier(Modifier::BOLD),
         )));
-        let model = self.state.current_model.as_deref().unwrap_or("(selecting...)");
+        let model = self
+            .state
+            .current_model
+            .as_deref()
+            .unwrap_or("(selecting...)");
         let inner_w = area.width.saturating_sub(4) as usize;
         let display_model = if model.len() > inner_w {
             &model[..inner_w]
@@ -616,7 +620,12 @@ impl Shell {
             ("speech", "Speech"),
         ];
         for (loop_name, display_name) in &loop_order {
-            let enabled = self.state.loop_states.get(*loop_name).copied().unwrap_or(true);
+            let enabled = self
+                .state
+                .loop_states
+                .get(*loop_name)
+                .copied()
+                .unwrap_or(true);
             let (dot, color) = if enabled {
                 ("\u{25cf}", Color::Green)
             } else {
@@ -1168,10 +1177,7 @@ impl Shell {
                     return result;
                 }
                 Err(e) => {
-                    self.add_message(
-                        MessageRole::Warning,
-                        format!("Command failed: {}", e),
-                    );
+                    self.add_message(MessageRole::Warning, format!("Command failed: {}", e));
                     self.verbose = command_state.verbose;
                     self.voice_enabled = command_state.voice_enabled;
                     self.transparency_loading = command_state.transparency_loading;
@@ -1289,7 +1295,10 @@ impl<'a> DispatchTarget<'a> {
     async fn send_event(&mut self, event: Event) -> Result<()> {
         match self {
             Self::LocalBus(bus) => {
-                if matches!(event, Event::Inference(InferenceEvent::InferenceRequested { .. })) {
+                if matches!(
+                    event,
+                    Event::Inference(InferenceEvent::InferenceRequested { .. })
+                ) {
                     bus.send_directed("inference", event)
                         .await
                         .map_err(|e| anyhow::anyhow!("directed send failed: {}", e))
@@ -1299,7 +1308,9 @@ impl<'a> DispatchTarget<'a> {
                         .map_err(|e| anyhow::anyhow!("bus broadcast failed: {}", e))
                 }
             }
-            Self::Noop => Err(anyhow::anyhow!("dispatch target does not support send_event")),
+            Self::Noop => Err(anyhow::anyhow!(
+                "dispatch target does not support send_event"
+            )),
         }
     }
 
@@ -1427,16 +1438,23 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
     let cmd = lower.split_whitespace().next().unwrap_or("");
     match cmd {
         "/observation" | "/obs" => {
-            add_message(deps.state, MessageRole::System, "Querying current observation...");
+            add_message(
+                deps.state,
+                MessageRole::System,
+                "Querying current observation...",
+            );
             deps.command_state.transparency_loading = true;
             deps.command_state.pending_transparency = Some(PendingTransparencyQuery {
                 query: TransparencyQuery::CurrentObservation,
                 started_at: Instant::now(),
             });
             transport
-                .send(target, Event::Transparency(BusTransparencyEvent::QueryRequested(
-                    TransparencyQuery::CurrentObservation,
-                )))
+                .send(
+                    target,
+                    Event::Transparency(BusTransparencyEvent::QueryRequested(
+                        TransparencyQuery::CurrentObservation,
+                    )),
+                )
                 .await?;
             Ok(DispatchResult::Continue)
         }
@@ -1448,23 +1466,33 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
                 started_at: Instant::now(),
             });
             transport
-                .send(target, Event::Transparency(BusTransparencyEvent::QueryRequested(
-                    TransparencyQuery::UserMemory,
-                )))
+                .send(
+                    target,
+                    Event::Transparency(BusTransparencyEvent::QueryRequested(
+                        TransparencyQuery::UserMemory,
+                    )),
+                )
                 .await?;
             Ok(DispatchResult::Continue)
         }
         "/explanation" | "/why" => {
-            add_message(deps.state, MessageRole::System, "Querying last inference...");
+            add_message(
+                deps.state,
+                MessageRole::System,
+                "Querying last inference...",
+            );
             deps.command_state.transparency_loading = true;
             deps.command_state.pending_transparency = Some(PendingTransparencyQuery {
                 query: TransparencyQuery::InferenceExplanation,
                 started_at: Instant::now(),
             });
             transport
-                .send(target, Event::Transparency(BusTransparencyEvent::QueryRequested(
-                    TransparencyQuery::InferenceExplanation,
-                )))
+                .send(
+                    target,
+                    Event::Transparency(BusTransparencyEvent::QueryRequested(
+                        TransparencyQuery::InferenceExplanation,
+                    )),
+                )
                 .await?;
             Ok(DispatchResult::Continue)
         }
@@ -1476,7 +1504,11 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
         }
         "/verbose" => {
             deps.command_state.verbose = !deps.command_state.verbose;
-            let status = if deps.command_state.verbose { "ON" } else { "OFF" };
+            let status = if deps.command_state.verbose {
+                "ON"
+            } else {
+                "OFF"
+            };
             add_message(
                 deps.state,
                 MessageRole::System,
@@ -1496,8 +1528,16 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
             }
 
             deps.command_state.voice_enabled = !deps.command_state.voice_enabled;
-            let state = if deps.command_state.voice_enabled { "ON" } else { "OFF" };
-            add_message(deps.state, MessageRole::System, &format!("VOICE: {}", state));
+            let state = if deps.command_state.voice_enabled {
+                "ON"
+            } else {
+                "OFF"
+            };
+            add_message(
+                deps.state,
+                MessageRole::System,
+                &format!("VOICE: {}", state),
+            );
             add_message(
                 deps.state,
                 MessageRole::System,
@@ -1506,12 +1546,8 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
             Ok(DispatchResult::Continue)
         }
         "/speech" => {
-            show_speech_config_shared(
-                deps.runtime,
-                deps.state,
-                deps.command_state.voice_enabled,
-            )
-            .await;
+            show_speech_config_shared(deps.runtime, deps.state, deps.command_state.voice_enabled)
+                .await;
             Ok(DispatchResult::Continue)
         }
         "/listen" => {
@@ -1519,11 +1555,16 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
                 let session_id = deps.state.listen_session_id;
                 deps.state.listen_mode_active = false;
                 transport
-                    .send(target, Event::Speech(SpeechEvent::ListenModeStopRequested {
-                        session_id,
-                    }))
+                    .send(
+                        target,
+                        Event::Speech(SpeechEvent::ListenModeStopRequested { session_id }),
+                    )
                     .await?;
-                add_message(deps.state, MessageRole::System, "🎤 Stopping listen mode...");
+                add_message(
+                    deps.state,
+                    MessageRole::System,
+                    "🎤 Stopping listen mode...",
+                );
             } else {
                 let speech_enabled = load_speech_enabled(deps.runtime).await?;
                 if !speech_enabled {
@@ -1542,9 +1583,10 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
                 deps.state.listen_mode_active = true;
                 let session_id = deps.state.listen_session_id;
                 transport
-                    .send(target, Event::Speech(SpeechEvent::ListenModeRequested {
-                        session_id,
-                    }))
+                    .send(
+                        target,
+                        Event::Speech(SpeechEvent::ListenModeRequested { session_id }),
+                    )
                     .await?;
                 add_message(
                     deps.state,
@@ -1585,7 +1627,10 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
         "/close" | "/quit" | "/exit" | "/q" => Ok(DispatchResult::Close),
         "/shutdown" => {
             transport
-                .send(target, Event::System(bus::events::SystemEvent::ShutdownSignal))
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::ShutdownSignal),
+                )
                 .await?;
             Ok(DispatchResult::Shutdown)
         }
@@ -1600,34 +1645,58 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
     }
 }
 
-fn add_message(state: &mut crate::tui_state::ShellState<SlashDropdown>, role: MessageRole, text: &str) {
+fn add_message(
+    state: &mut crate::tui_state::ShellState<SlashDropdown>,
+    role: MessageRole,
+    text: &str,
+) {
     state.messages.push(Message::new(role, text.to_string()));
 }
 
 fn event_to_ipc_payload(event: &Event) -> Result<IpcPayload> {
     match event {
-        Event::Transparency(BusTransparencyEvent::QueryRequested(TransparencyQuery::CurrentObservation)) => {
-            Ok(IpcPayload::SlashCommand { line: "/observation".to_string() })
+        Event::Transparency(BusTransparencyEvent::QueryRequested(
+            TransparencyQuery::CurrentObservation,
+        )) => Ok(IpcPayload::SlashCommand {
+            line: "/observation".to_string(),
+        }),
+        Event::Transparency(BusTransparencyEvent::QueryRequested(
+            TransparencyQuery::UserMemory,
+        )) => Ok(IpcPayload::SlashCommand {
+            line: "/memory".to_string(),
+        }),
+        Event::Transparency(BusTransparencyEvent::QueryRequested(
+            TransparencyQuery::InferenceExplanation,
+        )) => Ok(IpcPayload::SlashCommand {
+            line: "/explanation".to_string(),
+        }),
+        Event::Speech(SpeechEvent::ListenModeRequested { session_id }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!("/listen start {}", session_id),
+            })
         }
-        Event::Transparency(BusTransparencyEvent::QueryRequested(TransparencyQuery::UserMemory)) => {
-            Ok(IpcPayload::SlashCommand { line: "/memory".to_string() })
+        Event::Speech(SpeechEvent::ListenModeStopRequested { session_id }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!("/listen stop {}", session_id),
+            })
         }
-        Event::Transparency(BusTransparencyEvent::QueryRequested(TransparencyQuery::InferenceExplanation)) => {
-            Ok(IpcPayload::SlashCommand { line: "/explanation".to_string() })
+        Event::System(bus::events::SystemEvent::ConfigSetRequested { key, value }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!("/config set {} {}", key, value),
+            })
         }
-        Event::Speech(SpeechEvent::ListenModeRequested { session_id }) => Ok(IpcPayload::SlashCommand {
-            line: format!("/listen start {}", session_id),
-        }),
-        Event::Speech(SpeechEvent::ListenModeStopRequested { session_id }) => Ok(IpcPayload::SlashCommand {
-            line: format!("/listen stop {}", session_id),
-        }),
-        Event::System(bus::events::SystemEvent::ConfigSetRequested { key, value }) => Ok(IpcPayload::SlashCommand {
-            line: format!("/config set {} {}", key, value),
-        }),
-        Event::System(bus::events::SystemEvent::LoopControlRequested { loop_name, enabled }) => Ok(IpcPayload::SlashCommand {
-            line: format!("/loops {} {}", loop_name, if *enabled { "on" } else { "off" }),
-        }),
-        Event::System(bus::events::SystemEvent::ShutdownSignal) => Ok(IpcPayload::ShutdownRequested),
+        Event::System(bus::events::SystemEvent::LoopControlRequested { loop_name, enabled }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!(
+                    "/loops {} {}",
+                    loop_name,
+                    if *enabled { "on" } else { "off" }
+                ),
+            })
+        }
+        Event::System(bus::events::SystemEvent::ShutdownSignal) => {
+            Ok(IpcPayload::ShutdownRequested)
+        }
         _ => Err(anyhow::anyhow!("event cannot be sent over IPC target")),
     }
 }
@@ -1643,7 +1712,8 @@ async fn current_models_dir(runtime: Option<&Runtime>) -> Result<PathBuf> {
         }
     }
 
-    runtime::ollama_models_dir().map_err(|e| anyhow::anyhow!("Could not resolve models directory: {}", e))
+    runtime::ollama_models_dir()
+        .map_err(|e| anyhow::anyhow!("Could not resolve models directory: {}", e))
 }
 
 async fn load_speech_enabled(runtime: Option<&Runtime>) -> Result<bool> {
@@ -1699,7 +1769,10 @@ async fn show_speech_config_shared(
     add_message(
         state,
         MessageRole::System,
-        &format!("voice_always_listening    {}", config.voice_always_listening),
+        &format!(
+            "voice_always_listening    {}",
+            config.voice_always_listening
+        ),
     );
     add_message(
         state,
@@ -1722,7 +1795,10 @@ async fn show_speech_config_shared(
     add_message(
         state,
         MessageRole::System,
-        &format!("voice_session_active      {}", if voice_enabled { "yes" } else { "no" }),
+        &format!(
+            "voice_session_active      {}",
+            if voice_enabled { "yes" } else { "no" }
+        ),
     );
 }
 
@@ -1754,7 +1830,11 @@ async fn show_screenshot_status_shared(
         MessageRole::System,
         &format!(
             "Screenshot capture: {} | Platform: {} | Active model: {} | Vision capable: {}",
-            if capture_enabled { "enabled" } else { "disabled" },
+            if capture_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
             platform_support,
             active_model,
             vision_status
@@ -1781,12 +1861,19 @@ async fn handle_microphone_command<T: MessageTransport + ?Sized>(
             .map_err(|_| anyhow::anyhow!("Usage: /microphone select <index>"))?;
         let devices = runtime::list_input_devices();
         if let Some((_, name)) = devices.into_iter().find(|(i, _)| *i == idx) {
-            let value = if idx == 0 { String::new() } else { name.clone() };
+            let value = if idx == 0 {
+                String::new()
+            } else {
+                name.clone()
+            };
             transport
-                .send(target, Event::System(bus::events::SystemEvent::ConfigSetRequested {
-                    key: "microphone_device".to_string(),
-                    value,
-                }))
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::ConfigSetRequested {
+                        key: "microphone_device".to_string(),
+                        value,
+                    }),
+                )
                 .await?;
             add_message(
                 state,
@@ -1801,7 +1888,10 @@ async fn handle_microphone_command<T: MessageTransport + ?Sized>(
             add_message(
                 state,
                 MessageRole::Warning,
-                &format!("No device at index {}. Run /microphone to list devices.", idx),
+                &format!(
+                    "No device at index {}. Run /microphone to list devices.",
+                    idx
+                ),
             );
         }
     } else {
@@ -1811,7 +1901,11 @@ async fn handle_microphone_command<T: MessageTransport + ?Sized>(
             add_message(state, MessageRole::Warning, "No input devices found.");
         } else {
             for (idx, name) in &devices {
-                add_message(state, MessageRole::System, &format!("  [{}]  {}", idx, name));
+                add_message(
+                    state,
+                    MessageRole::System,
+                    &format!("  [{}]  {}", idx, name),
+                );
             }
             add_message(
                 state,
@@ -1838,10 +1932,13 @@ async fn handle_config_command<T: MessageTransport + ?Sized>(
             String::new()
         };
         transport
-            .send(target, Event::System(bus::events::SystemEvent::ConfigSetRequested {
-                key: key.to_string(),
-                value: value.clone(),
-            }))
+            .send(
+                target,
+                Event::System(bus::events::SystemEvent::ConfigSetRequested {
+                    key: key.to_string(),
+                    value: value.clone(),
+                }),
+            )
             .await?;
         add_message(
             state,
@@ -1855,7 +1952,11 @@ async fn handle_config_command<T: MessageTransport + ?Sized>(
         let config = runtime::config::load_or_create_config().await?;
 
         add_message(state, MessageRole::System, "━━  Configuration");
-        add_message(state, MessageRole::System, &format!("Config file: {}", config_path));
+        add_message(
+            state,
+            MessageRole::System,
+            &format!("Config file: {}", config_path),
+        );
         match toml::to_string_pretty(&config) {
             Ok(toml_str) => {
                 for line in toml_str.lines() {
@@ -1896,17 +1997,24 @@ async fn handle_loops_command<T: MessageTransport + ?Sized>(
                 add_message(
                     state,
                     MessageRole::System,
-                    &format!("  {} — {}", label, if enabled { "enabled" } else { "disabled" }),
+                    &format!(
+                        "  {} — {}",
+                        label,
+                        if enabled { "enabled" } else { "disabled" }
+                    ),
                 );
             }
         }
         ["/loops", name] => {
             let enabled = !state.loop_states.get(*name).copied().unwrap_or(true);
             transport
-                .send(target, Event::System(bus::events::SystemEvent::LoopControlRequested {
-                    loop_name: (*name).to_string(),
-                    enabled,
-                }))
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::LoopControlRequested {
+                        loop_name: (*name).to_string(),
+                        enabled,
+                    }),
+                )
                 .await?;
             add_message(
                 state,
@@ -1928,10 +2036,13 @@ async fn handle_loops_command<T: MessageTransport + ?Sized>(
                 }
             };
             transport
-                .send(target, Event::System(bus::events::SystemEvent::LoopControlRequested {
-                    loop_name: (*name).to_string(),
-                    enabled,
-                }))
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::LoopControlRequested {
+                        loop_name: (*name).to_string(),
+                        enabled,
+                    }),
+                )
                 .await?;
             add_message(
                 state,
@@ -1978,7 +2089,10 @@ fn show_help_shared(state: &mut crate::tui_state::ShellState<SlashDropdown>) {
 fn show_actors_shared(state: &mut crate::tui_state::ShellState<SlashDropdown>) {
     add_message(state, MessageRole::System, "━━  Actor Status");
     for name in ["Platform", "Inference", "CTP", "Memory", "Soul"] {
-        let status = state.actor_health.get(name).unwrap_or(&ActorStatus::Starting);
+        let status = state
+            .actor_health
+            .get(name)
+            .unwrap_or(&ActorStatus::Starting);
         let text = match status {
             ActorStatus::Ready => "Ready".to_string(),
             ActorStatus::Starting => "Starting".to_string(),
@@ -2234,7 +2348,9 @@ fn transparency_timeout_message(query: &TransparencyQuery) -> String {
 #[allow(dead_code)]
 fn verbose_format(ev: &Event) -> Option<String> {
     match ev {
-        Event::CTP(bus::events::CTPEvent::ThoughtEventTriggered(_)) => {
+        Event::CTP(ctp_event)
+            if matches!(**ctp_event, bus::events::CTPEvent::ThoughtEventTriggered(_)) =>
+        {
             Some("[verbose] CTP: thought triggered".to_string())
         }
         Event::Soul(bus::events::SoulEvent::EventLogged(e)) => {
@@ -2294,7 +2410,7 @@ pub async fn run_with_ipc() -> anyhow::Result<()> {
     let mut state = crate::tui_state::ShellState::new();
     state.add_welcome_message("Connected to Sena daemon — local-first ambient AI");
     state.add_welcome_message("Type /help for commands, or chat freely.");
-    
+
     // Seed current_model from SessionReady handshake.
     state.current_model = initial_model;
 
@@ -2320,7 +2436,10 @@ pub async fn run_with_ipc() -> anyhow::Result<()> {
 }
 
 enum ShellMode {
-    Local { runtime: Arc<Runtime>, shell: Shell },
+    Local {
+        runtime: Arc<Runtime>,
+        shell: Shell,
+    },
     Ipc {
         state: crate::tui_state::ShellState<SlashDropdown>,
         command_state: CommandRuntimeState,
@@ -2402,7 +2521,9 @@ impl ShellMode {
                         }
                     }
                 } else {
-                    state.messages.push(Message::new(MessageRole::User, line.to_string()));
+                    state
+                        .messages
+                        .push(Message::new(MessageRole::User, line.to_string()));
                     let request_id = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .map(|d| d.as_nanos() as u64)
@@ -2433,7 +2554,10 @@ impl ShellMode {
         match self {
             Self::Local { shell, .. } => {
                 if let DisplayMessage::BusEvent(event) = message {
-                    if matches!(*event, Event::System(bus::events::SystemEvent::ShutdownSignal)) {
+                    if matches!(
+                        *event,
+                        Event::System(bus::events::SystemEvent::ShutdownSignal)
+                    ) {
                         tracing::info!("cli: ShutdownSignal received on bus — exiting shell");
                         return Some(ShellExitReason::Shutdown);
                     }
@@ -2471,9 +2595,10 @@ impl ShellMode {
                         IpcPayload::Pong | IpcPayload::Ack { .. } => {}
                         IpcPayload::Error { reason, .. } => {
                             state.waiting_for_inference = false;
-                            state
-                                .messages
-                                .push(Message::new(MessageRole::Warning, format!("Error: {}", reason)));
+                            state.messages.push(Message::new(
+                                MessageRole::Warning,
+                                format!("Error: {}", reason),
+                            ));
                         }
                         IpcPayload::LoopStatusUpdate { loop_name, enabled } => {
                             state.loop_states.insert(loop_name, enabled);
@@ -2521,7 +2646,10 @@ impl ShellMode {
                 config.preferred_model = Some(model_name.clone());
                 match runtime::save_config(&config).await {
                     Ok(_) => {
-                        shell.add_message(MessageRole::System, format!("Selected model: {}", model_name));
+                        shell.add_message(
+                            MessageRole::System,
+                            format!("Selected model: {}", model_name),
+                        );
                         shell.add_message(
                             MessageRole::System,
                             "Model change will take effect after restart.".to_string(),
@@ -2579,7 +2707,11 @@ async fn run_shell<T: MessageTransport>(
 
     'main: loop {
         if let Err(e) = terminal.draw(|f| mode.render(f)) {
-            add_message(mode.state_mut(), MessageRole::Warning, &format!("Display error: {}", e));
+            add_message(
+                mode.state_mut(),
+                MessageRole::Warning,
+                &format!("Display error: {}", e),
+            );
         }
 
         if let Some(first_press) = mode.state().ctrl_c_first_press {
@@ -2823,10 +2955,7 @@ async fn run_shell<T: MessageTransport>(
 }
 
 /// Simplified TUI rendering for IPC mode.
-fn render_ipc_tui(
-    frame: &mut ratatui::Frame,
-    state: &crate::tui_state::ShellState<SlashDropdown>,
-) {
+fn render_ipc_tui(frame: &mut ratatui::Frame, state: &crate::tui_state::ShellState<SlashDropdown>) {
     // ── Vertical layout: header / body / input ────────────────────────────────
     let main_chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -2967,11 +3096,7 @@ fn render_ipc_tui(
     frame.render_widget(paragraph, body_chunks[0]);
 
     // ── Sidebar ───────────────────────────────────────────────────────────────────
-    render_ipc_sidebar(
-        frame,
-        body_chunks[1],
-        state,
-    );
+    render_ipc_sidebar(frame, body_chunks[1], state);
 
     // Input area
     let prompt_line = Line::from(vec![
@@ -3121,7 +3246,10 @@ fn render_ipc_sidebar(
     )));
     let actor_names = ["Platform", "Inference", "CTP", "Memory", "Soul"];
     for name in &actor_names {
-        let status = state.actor_health.get(name).unwrap_or(&ActorStatus::Starting);
+        let status = state
+            .actor_health
+            .get(name)
+            .unwrap_or(&ActorStatus::Starting);
         let (dot, color, label) = match status {
             ActorStatus::Ready => ("\u{25cf}", Color::Green, "Ready"),
             ActorStatus::Starting => ("\u{25cb}", Color::Yellow, "Starting"),

--- a/crates/cli/src/tui_state.rs
+++ b/crates/cli/src/tui_state.rs
@@ -230,10 +230,8 @@ impl<T> ShellState<T> {
 
     /// Add a welcome message to the conversation log.
     pub fn add_welcome_message(&mut self, text: &str) {
-        self.messages.push(Message::new(
-            MessageRole::System,
-            text.to_string(),
-        ));
+        self.messages
+            .push(Message::new(MessageRole::System, text.to_string()));
     }
 }
 

--- a/crates/ctp/src/actor.rs
+++ b/crates/ctp/src/actor.rs
@@ -182,14 +182,14 @@ impl Actor for CTPActor {
 
                     // Emit ContextSnapshotReady event on each tick so downstream
                     // actors can observe context evolution even when no trigger fires.
-                    bus.broadcast(Event::CTP(CTPEvent::ContextSnapshotReady(snapshot.clone())))
+                    bus.broadcast(Event::CTP(Box::new(CTPEvent::ContextSnapshotReady(snapshot.clone()))))
                         .await
                         .map_err(|e| ActorError::RuntimeError(format!("failed to broadcast ContextSnapshotReady: {}", e)))?;
 
                     // Check if we should trigger
                     if self.boot_complete && self.gate.should_trigger(&snapshot) {
                         // Emit ThoughtEventTriggered event
-                        bus.broadcast(Event::CTP(CTPEvent::ThoughtEventTriggered(snapshot)))
+                        bus.broadcast(Event::CTP(Box::new(CTPEvent::ThoughtEventTriggered(snapshot))))
                             .await
                             .map_err(|e| ActorError::RuntimeError(format!("failed to broadcast ThoughtEventTriggered: {}", e)))?;
                     }
@@ -278,7 +278,7 @@ impl CTPActor {
         let response = handle_current_observation(self.refresh_snapshot());
 
         bus.broadcast(Event::Transparency(
-            TransparencyEvent::ObservationResponded(response),
+            TransparencyEvent::ObservationResponded(Box::new(response)),
         ))
         .await
         .map_err(|e| format!("failed to broadcast ObservationResponded: {}", e))

--- a/crates/ctp/src/context_assembler.rs
+++ b/crates/ctp/src/context_assembler.rs
@@ -2,7 +2,7 @@
 
 use std::time::{Duration, Instant};
 
-use bus::events::ctp::{ContextSnapshot, TaskHint};
+use bus::events::ctp::{ContextSnapshot, EnrichedInferredTask};
 use bus::events::platform::{KeystrokeCadence, WindowContext};
 
 use crate::signal_buffer::SignalBuffer;
@@ -97,6 +97,7 @@ impl ContextAssembler {
             keystroke_cadence,
             session_duration,
             inferred_task,
+            user_state: None,
             visual_context,
             timestamp: now,
         }
@@ -107,7 +108,7 @@ fn infer_task_hint(
     app_name: &str,
     window_title: Option<&str>,
     cadence: &KeystrokeCadence,
-) -> Option<TaskHint> {
+) -> Option<EnrichedInferredTask> {
     let app = app_name.to_lowercase();
     let title = window_title.unwrap_or_default().to_lowercase();
 
@@ -142,8 +143,17 @@ fn infer_task_hint(
         confidence += 0.05;
     }
 
-    Some(TaskHint {
+    let semantic_description = match category {
+        "coding" => format!("Writing code in {}", app_name),
+        "research" => format!("Researching in {}", app_name),
+        "writing" => format!("Writing in {}", app_name),
+        "operations" => format!("Running commands in {}", app_name),
+        _ => format!("Working in {}", app_name),
+    };
+
+    Some(EnrichedInferredTask {
         category: category.to_owned(),
+        semantic_description,
         confidence: confidence.min(0.95) as f32,
     })
 }
@@ -157,7 +167,7 @@ impl Default for ContextAssembler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bus::events::ctp::TaskHint;
+    use bus::events::ctp::EnrichedInferredTask;
     use bus::events::platform::{ClipboardDigest, FileEvent, FileEventKind, WindowContext};
     use std::path::PathBuf;
     use std::thread::sleep;
@@ -288,10 +298,12 @@ mod tests {
                 timestamp: Instant::now(),
             },
             session_duration: Duration::from_secs(30),
-            inferred_task: Some(TaskHint {
+            inferred_task: Some(EnrichedInferredTask {
                 category: "coding".to_string(),
+                semantic_description: "Writing code".to_string(),
                 confidence: 0.8,
             }),
+            user_state: None,
             visual_context: None,
             timestamp: Instant::now(),
         };

--- a/crates/ctp/src/ctp_actor.rs
+++ b/crates/ctp/src/ctp_actor.rs
@@ -184,14 +184,14 @@ impl Actor for CTPActor {
 
                     // Emit ContextSnapshotReady event on each tick so downstream
                     // actors can observe context evolution even when no trigger fires.
-                    bus.broadcast(Event::CTP(CTPEvent::ContextSnapshotReady(snapshot.clone())))
+                    bus.broadcast(Event::CTP(Box::new(CTPEvent::ContextSnapshotReady(snapshot.clone()))))
                         .await
                         .map_err(|e| ActorError::RuntimeError(format!("failed to broadcast ContextSnapshotReady: {}", e)))?;
 
                     // Check if we should trigger
                     if self.boot_complete && self.gate.should_trigger(&snapshot) {
                         // Emit ThoughtEventTriggered event
-                        bus.broadcast(Event::CTP(CTPEvent::ThoughtEventTriggered(snapshot)))
+                        bus.broadcast(Event::CTP(Box::new(CTPEvent::ThoughtEventTriggered(snapshot))))
                             .await
                             .map_err(|e| ActorError::RuntimeError(format!("failed to broadcast ThoughtEventTriggered: {}", e)))?;
                     }
@@ -280,7 +280,7 @@ impl CTPActor {
         let response = handle_current_observation(self.refresh_snapshot());
 
         bus.broadcast(Event::Transparency(
-            TransparencyEvent::ObservationResponded(response),
+            TransparencyEvent::ObservationResponded(Box::new(response)),
         ))
         .await
         .map_err(|e| format!("failed to broadcast ObservationResponded: {}", e))

--- a/crates/ctp/src/transparency_query.rs
+++ b/crates/ctp/src/transparency_query.rs
@@ -40,6 +40,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(5),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: Instant::now(),
         };

--- a/crates/ctp/src/trigger_gate.rs
+++ b/crates/ctp/src/trigger_gate.rs
@@ -143,7 +143,7 @@ fn context_diff_score(prev: &ContextSnapshot, current: &ContextSnapshot) -> f64 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bus::events::ctp::TaskHint;
+    use bus::events::ctp::EnrichedInferredTask;
     use bus::events::platform::{KeystrokeCadence, WindowContext};
     use std::thread::sleep;
 
@@ -166,6 +166,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(10),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }
@@ -237,13 +238,15 @@ mod tests {
     fn task_change_contributes_to_diff_score() {
         let mut gate = TriggerGate::new(Duration::from_secs(9999)).with_sensitivity(1.0);
         let mut first = snapshot("Code");
-        first.inferred_task = Some(TaskHint {
+        first.inferred_task = Some(EnrichedInferredTask {
             category: "coding".to_owned(),
+            semantic_description: "Writing code".to_string(),
             confidence: 0.8,
         });
         let mut second = snapshot("Code");
-        second.inferred_task = Some(TaskHint {
+        second.inferred_task = Some(EnrichedInferredTask {
             category: "research".to_owned(),
+            semantic_description: "Reading documentation".to_string(),
             confidence: 0.7,
         });
 

--- a/crates/inference/src/actor.rs
+++ b/crates/inference/src/actor.rs
@@ -372,12 +372,12 @@ impl InferenceActor {
                     None => return Err(err),
                 };
 
-                let retry_max_tokens = match Self::compute_retry_max_tokens(overflow, params.max_tokens)
-                {
-                    Ok(Some(v)) => v,
-                    Ok(None) => return Err(err),
-                    Err(e) => return Err(e.to_string()),
-                };
+                let retry_max_tokens =
+                    match Self::compute_retry_max_tokens(overflow, params.max_tokens) {
+                        Ok(Some(v)) => v,
+                        Ok(None) => return Err(err),
+                        Err(e) => return Err(e.to_string()),
+                    };
 
                 tracing::warn!(
                     "inference: context overflow on first attempt; retrying once with max_tokens {} -> {} (prompt={}, context={})",
@@ -1651,13 +1651,14 @@ impl Actor for InferenceActor {
                         Ok(Event::System(SystemEvent::ShutdownSignal)) => {
                             return Ok(());
                         }
-                        Ok(Event::CTP(CTPEvent::ContextSnapshotReady(snapshot))) => {
-                            self.last_snapshot = Some(snapshot);
-                        }
-                        Ok(Event::CTP(CTPEvent::ThoughtEventTriggered(snapshot))) => {
-                            // Proactive inference: CTP determined context is worth reasoning about.
-                            // Compose a context-derived prompt and run inference.
-                            self.last_snapshot = Some(snapshot.clone());
+                        Ok(Event::CTP(ctp_event)) => match *ctp_event {
+                            CTPEvent::ContextSnapshotReady(snapshot) => {
+                                self.last_snapshot = Some(snapshot);
+                            }
+                            CTPEvent::ThoughtEventTriggered(snapshot) => {
+                                // Proactive inference: CTP determined context is worth reasoning about.
+                                // Compose a context-derived prompt and run inference.
+                                self.last_snapshot = Some(snapshot.clone());
 
                             // Guard: only run proactive inference if the model is already loaded.
                             // Never call ensure_loaded() proactively — model loading is an
@@ -1717,7 +1718,9 @@ impl Actor for InferenceActor {
                                         .await;
                                 }
                             }
-                        }
+                            }
+                            _ => {} // Ignore other CTPEvent variants
+                        },
                         Ok(Event::Speech(SpeechEvent::TranscriptionCompleted {
                             text,
                             confidence: _,
@@ -2565,6 +2568,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(3600),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: Instant::now(),
         };
@@ -2601,6 +2605,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(1200),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: Instant::now(),
         };

--- a/crates/memory/src/working_memory.rs
+++ b/crates/memory/src/working_memory.rs
@@ -158,6 +158,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(0),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }

--- a/crates/prompt/src/composer.rs
+++ b/crates/prompt/src/composer.rs
@@ -122,6 +122,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(3600),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }

--- a/crates/runtime/src/ipc_server.rs
+++ b/crates/runtime/src/ipc_server.rs
@@ -1002,7 +1002,12 @@ fn event_to_display_line(event: &Event) -> Option<IpcMessage> {
                 style: LineStyle::Error,
             },
         }),
-        Event::CTP(bus::events::ctp::CTPEvent::ThoughtEventTriggered(_thought)) => {
+        Event::CTP(ctp_event)
+            if matches!(
+                **ctp_event,
+                bus::events::ctp::CTPEvent::ThoughtEventTriggered(_)
+            ) =>
+        {
             // Only show in verbose mode (CLI-managed state).
             None
         }

--- a/crates/soul/src/actor.rs
+++ b/crates/soul/src/actor.rs
@@ -346,6 +346,20 @@ impl SoulActor {
             CTPEvent::ThoughtEventTriggered(_) => {
                 self.increment_identity_counter("ctp::thought_trigger_count", 1)?;
             }
+            CTPEvent::UserStateComputed(user_state) => {
+                // Absorb user state signals for behavioral pattern analysis
+                if user_state.flow_detected {
+                    self.increment_identity_counter("user_state::flow_state_count", 1)?;
+                }
+                if user_state.frustration_level > 70 {
+                    self.increment_identity_counter("user_state::high_frustration_count", 1)?;
+                }
+            }
+            CTPEvent::SignalPatternDetected(pattern) => {
+                // Absorb detected signal patterns for identity distillation
+                let key = format!("pattern::{:?}", pattern.pattern_type).to_lowercase();
+                self.increment_identity_counter(&key, 1)?;
+            }
         }
         Ok(())
     }
@@ -617,7 +631,7 @@ impl Actor for SoulActor {
                             let _ = self.absorb_platform_signal(platform_event);
                         }
                         Ok(Event::CTP(ctp_event)) => {
-                            let _ = self.absorb_ctp_signal(ctp_event);
+                            let _ = self.absorb_ctp_signal(*ctp_event);
                         }
                         Ok(Event::Inference(inference_event)) => {
                             let _ = self.absorb_inference_signal(inference_event);


### PR DESCRIPTION
## Phase 7A — Bus Intelligence Events

Closes #21

New typed events for CTP intelligence (UserStateComputed, SignalPatternDetected, EnrichedInferredTask), Soul intelligence (IdentitySignalDistilled, TemporalPatternDetected, PreferenceLearningUpdate, RichSummaryRequested/Ready), Memory (ContextQueryRequested/Completed), and Speech (LowConfidenceTranscription). CTP event variant boxed to reduce Event enum size.

**Arch-guard:** APPROVED
**Reviewer:** APPROVED
**Tests:** 95 bus tests passing