### PR TITLE
Phase 7A: Soul intelligence layer — distillation, temporal, preferences, summaries

### DIFF
--- a/crates/bus/src/bus.rs
+++ b/crates/bus/src/bus.rs
@@ -19,7 +19,7 @@ pub enum Event {
     /// Platform vision events (screen capture digests, visual context).
     PlatformVision(PlatformVisionEvent),
     /// CTP (Continuous Thought Processing) events.
-    CTP(CTPEvent),
+    CTP(Box<CTPEvent>),
     /// Inference-layer events (model discovery, inference requests/responses).
     Inference(InferenceEvent),
     /// Memory subsystem events (write/query requests and responses).

--- a/crates/bus/src/events/ctp.rs
+++ b/crates/bus/src/events/ctp.rs
@@ -32,6 +32,59 @@ pub struct TaskHint {
     pub confidence: f32,
 }
 
+/// Enriched inferred task with semantic description.
+/// Replacement for TaskHint with richer context.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnrichedInferredTask {
+    /// Task category (e.g., "coding", "writing", "research").
+    pub category: String,
+    /// Semantic description of what the user appears to be doing.
+    pub semantic_description: String,
+    /// Confidence level for the inference (0.0 to 1.0).
+    pub confidence: f32,
+}
+
+impl From<TaskHint> for EnrichedInferredTask {
+    fn from(hint: TaskHint) -> Self {
+        EnrichedInferredTask {
+            category: hint.category.clone(),
+            semantic_description: hint.category,
+            confidence: hint.confidence,
+        }
+    }
+}
+
+/// User cognitive state derived from behavioral signals.
+#[derive(Debug, Clone)]
+pub struct UserState {
+    /// Frustration level (0-100).
+    pub frustration_level: u8,
+    /// Whether the user is in a flow state.
+    pub flow_detected: bool,
+    /// Cost of context switching (0-100).
+    pub context_switch_cost: u8,
+}
+
+/// Type of signal pattern detected.
+#[derive(Debug, Clone)]
+pub enum SignalPatternType {
+    Frustration,
+    Repetition,
+    FlowState,
+    Anomaly,
+}
+
+/// Detected signal pattern from multi-modal signal analysis.
+#[derive(Debug, Clone)]
+pub struct SignalPattern {
+    /// Type of pattern detected.
+    pub pattern_type: SignalPatternType,
+    /// Confidence in the pattern detection (0.0 to 1.0).
+    pub confidence: f32,
+    /// Human-readable description of the pattern.
+    pub description: String,
+}
+
 /// Structured capture of user's computing context at a moment in time.
 ///
 /// This is the typed output of the CTP Context Assembler.
@@ -49,7 +102,9 @@ pub struct ContextSnapshot {
     /// Duration of the current session.
     pub session_duration: Duration,
     /// Inferred task, if any.
-    pub inferred_task: Option<TaskHint>,
+    pub inferred_task: Option<EnrichedInferredTask>,
+    /// User cognitive state, if computed.
+    pub user_state: Option<UserState>,
     /// Visual context from screen capture, if recent and enabled.
     pub visual_context: Option<VisualContext>,
     /// When this snapshot was captured.
@@ -63,6 +118,10 @@ pub enum CTPEvent {
     ContextSnapshotReady(ContextSnapshot),
     /// A thought event has been triggered based on a context snapshot.
     ThoughtEventTriggered(ContextSnapshot),
+    /// User cognitive state has been computed.
+    UserStateComputed(UserState),
+    /// A signal pattern has been detected.
+    SignalPatternDetected(SignalPattern),
 }
 
 #[cfg(test)]
@@ -107,8 +166,9 @@ mod tests {
             timestamp: now,
         };
 
-        let task_hint = TaskHint {
+        let task = EnrichedInferredTask {
             category: "coding".to_string(),
+            semantic_description: "Editing Rust code in VSCode".to_string(),
             confidence: 0.92,
         };
 
@@ -118,7 +178,8 @@ mod tests {
             clipboard_digest: Some("sha256:abcdef1234567890".to_string()),
             keystroke_cadence,
             session_duration: Duration::from_secs(3600),
-            inferred_task: Some(task_hint),
+            inferred_task: Some(task),
+            user_state: None,
             visual_context: None,
             timestamp: now,
         };
@@ -133,9 +194,9 @@ mod tests {
         assert_eq!(snapshot.keystroke_cadence.events_per_minute, 180.5);
         assert_eq!(snapshot.session_duration, Duration::from_secs(3600));
         assert!(snapshot.inferred_task.is_some());
-        if let Some(hint) = &snapshot.inferred_task {
-            assert_eq!(hint.category, "coding");
-            assert_eq!(hint.confidence, 0.92);
+        if let Some(task) = &snapshot.inferred_task {
+            assert_eq!(task.category, "coding");
+            assert_eq!(task.confidence, 0.92);
         }
     }
 
@@ -160,6 +221,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(1800),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         };
@@ -240,6 +302,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(0),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }

--- a/crates/bus/src/events/soul.rs
+++ b/crates/bus/src/events/soul.rs
@@ -80,6 +80,90 @@ pub struct PersonalityUpdated {
     pub verbosity: u8,
 }
 
+/// Distilled identity signal extracted from behavioral patterns.
+#[derive(Debug, Clone)]
+pub struct DistilledIdentitySignal {
+    /// The signal's semantic key (e.g., "preferred_editor", "work_start_time").
+    pub signal_key: String,
+    /// The signal's value (e.g., "vscode", "09:00").
+    pub signal_value: String,
+    /// Confidence in this signal's accuracy (0.0 to 1.0).
+    pub confidence: f32,
+    /// Number of source events that contributed to this signal.
+    pub source_event_count: u32,
+}
+
+/// Temporal behavior pattern derived from event log analysis.
+#[derive(Debug, Clone)]
+pub struct TemporalBehaviorPattern {
+    /// Hour of day (0-23), if time-of-day is relevant.
+    pub hour_of_day: Option<u8>,
+    /// Day of week (0=Monday, 6=Sunday), if day-of-week is relevant.
+    pub day_of_week: Option<u8>,
+    /// Semantic category of the behavior (e.g., "deep_work", "meetings").
+    pub behavior_category: String,
+    /// How often this pattern occurs (event count).
+    pub frequency: u32,
+}
+
+/// User engagement signal in response to Sena's proactive inference.
+#[derive(Debug, Clone)]
+pub enum EngagementSignal {
+    /// User explicitly accepted or acted on the response.
+    Accepted,
+    /// User ignored the response (no interaction within timeout).
+    Ignored,
+    /// User interrupted or dismissed the response.
+    Interrupted,
+    /// User asked a follow-up question.
+    FollowUpQuery,
+}
+
+/// Type of Soul content section in a rich summary.
+#[derive(Debug, Clone)]
+pub enum SoulSectionType {
+    /// Recent event log entries.
+    RecentEvents,
+    /// Distilled identity signals.
+    IdentitySignals,
+    /// Temporal habit patterns.
+    TemporalHabits,
+    /// User preferences.
+    Preferences,
+}
+
+/// A single section of a rich Soul summary.
+#[derive(Debug, Clone)]
+pub struct SoulSection {
+    /// Type of content in this section.
+    pub section_type: SoulSectionType,
+    /// The actual content text.
+    pub content: String,
+    /// Relevance score for prompt prioritization (0.0 to 1.0).
+    pub relevance_score: f32,
+}
+
+/// Rich structured summary of Soul state for prompt composition.
+#[derive(Clone)]
+pub struct RichSoulSummary {
+    /// Ordered sections (highest relevance first).
+    pub sections: Vec<SoulSection>,
+    /// Total token count (approximate).
+    pub token_count: usize,
+    /// Request ID for correlation.
+    pub request_id: u64,
+}
+
+impl std::fmt::Debug for RichSoulSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RichSoulSummary")
+            .field("sections", &format!("{} sections", self.sections.len()))
+            .field("token_count", &self.token_count)
+            .field("request_id", &self.request_id)
+            .finish()
+    }
+}
+
 /// Request for a transparency view of the Soul state for transparency queries.
 #[derive(Debug, Clone)]
 pub struct SoulReadRequest {
@@ -130,6 +214,26 @@ pub enum SoulEvent {
         /// Failure reason.
         reason: String,
     },
+    /// A distilled identity signal has been extracted.
+    IdentitySignalDistilled(DistilledIdentitySignal),
+    /// A temporal behavior pattern has been detected.
+    TemporalPatternDetected(TemporalBehaviorPattern),
+    /// User engagement signal in response to a proactive inference.
+    PreferenceLearningUpdate {
+        /// ID of the response that triggered this signal.
+        response_id: u64,
+        /// The engagement signal type.
+        signal: EngagementSignal,
+    },
+    /// Request for a rich, structured Soul summary.
+    RichSummaryRequested {
+        /// Token budget for the summary.
+        token_budget: usize,
+        /// Request ID for correlation.
+        request_id: u64,
+    },
+    /// Rich summary is ready.
+    RichSummaryReady(RichSoulSummary),
 }
 
 #[cfg(test)]

--- a/crates/bus/src/events/transparency.rs
+++ b/crates/bus/src/events/transparency.rs
@@ -80,7 +80,7 @@ pub struct ModelListResponse {
 #[derive(Debug, Clone)]
 pub enum TransparencyEvent {
     QueryRequested(TransparencyQuery),
-    ObservationResponded(ObservationResponse),
+    ObservationResponded(Box<ObservationResponse>),
     MemoryResponded(MemoryResponse),
     InferenceExplanationResponded(InferenceExplanationResponse),
     ModelListResponded(ModelListResponse),

--- a/crates/bus/src/lib.rs
+++ b/crates/bus/src/lib.rs
@@ -45,6 +45,7 @@ mod integration_tests {
             },
             session_duration: Duration::from_secs(0),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }

--- a/crates/cli/src/query.rs
+++ b/crates/cli/src/query.rs
@@ -394,10 +394,12 @@ mod tests {
                 timestamp: std::time::Instant::now(),
             },
             session_duration: Duration::from_secs(3600),
-            inferred_task: Some(bus::events::ctp::TaskHint {
+            inferred_task: Some(bus::events::ctp::EnrichedInferredTask {
                 category: "coding".to_string(),
+                semantic_description: "Writing Rust code".to_string(),
                 confidence: 0.92,
             }),
+            user_state: None,
             visual_context: None,
             timestamp: std::time::Instant::now(),
         };
@@ -431,6 +433,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(0),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: std::time::Instant::now(),
         };

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -240,12 +240,12 @@ impl Shell {
     /// Create a new Shell instance.
     fn new(runtime: Arc<Runtime>) -> Self {
         let voice_enabled = runtime.config.speech_enabled;
-        
+
         // Initialize shared state with welcome messages.
         let mut state = crate::tui_state::ShellState::new();
         state.add_welcome_message("Welcome to Sena — local-first ambient AI");
         state.add_welcome_message("Type /help for commands, or chat freely.");
-        
+
         // Seed current_model from runtime config.
         state.current_model = runtime.config.preferred_model.clone();
 
@@ -509,7 +509,11 @@ impl Shell {
                 .fg(Color::LightMagenta)
                 .add_modifier(Modifier::BOLD),
         )));
-        let model = self.state.current_model.as_deref().unwrap_or("(selecting...)");
+        let model = self
+            .state
+            .current_model
+            .as_deref()
+            .unwrap_or("(selecting...)");
         let inner_w = area.width.saturating_sub(4) as usize;
         let display_model = if model.len() > inner_w {
             &model[..inner_w]
@@ -616,7 +620,12 @@ impl Shell {
             ("speech", "Speech"),
         ];
         for (loop_name, display_name) in &loop_order {
-            let enabled = self.state.loop_states.get(*loop_name).copied().unwrap_or(true);
+            let enabled = self
+                .state
+                .loop_states
+                .get(*loop_name)
+                .copied()
+                .unwrap_or(true);
             let (dot, color) = if enabled {
                 ("\u{25cf}", Color::Green)
             } else {
@@ -1168,10 +1177,7 @@ impl Shell {
                     return result;
                 }
                 Err(e) => {
-                    self.add_message(
-                        MessageRole::Warning,
-                        format!("Command failed: {}", e),
-                    );
+                    self.add_message(MessageRole::Warning, format!("Command failed: {}", e));
                     self.verbose = command_state.verbose;
                     self.voice_enabled = command_state.voice_enabled;
                     self.transparency_loading = command_state.transparency_loading;
@@ -1289,7 +1295,10 @@ impl<'a> DispatchTarget<'a> {
     async fn send_event(&mut self, event: Event) -> Result<()> {
         match self {
             Self::LocalBus(bus) => {
-                if matches!(event, Event::Inference(InferenceEvent::InferenceRequested { .. })) {
+                if matches!(
+                    event,
+                    Event::Inference(InferenceEvent::InferenceRequested { .. })
+                ) {
                     bus.send_directed("inference", event)
                         .await
                         .map_err(|e| anyhow::anyhow!("directed send failed: {}", e))
@@ -1299,7 +1308,9 @@ impl<'a> DispatchTarget<'a> {
                         .map_err(|e| anyhow::anyhow!("bus broadcast failed: {}", e))
                 }
             }
-            Self::Noop => Err(anyhow::anyhow!("dispatch target does not support send_event")),
+            Self::Noop => Err(anyhow::anyhow!(
+                "dispatch target does not support send_event"
+            )),
         }
     }
 
@@ -1427,16 +1438,23 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
     let cmd = lower.split_whitespace().next().unwrap_or("");
     match cmd {
         "/observation" | "/obs" => {
-            add_message(deps.state, MessageRole::System, "Querying current observation...");
+            add_message(
+                deps.state,
+                MessageRole::System,
+                "Querying current observation...",
+            );
             deps.command_state.transparency_loading = true;
             deps.command_state.pending_transparency = Some(PendingTransparencyQuery {
                 query: TransparencyQuery::CurrentObservation,
                 started_at: Instant::now(),
             });
             transport
-                .send(target, Event::Transparency(BusTransparencyEvent::QueryRequested(
-                    TransparencyQuery::CurrentObservation,
-                )))
+                .send(
+                    target,
+                    Event::Transparency(BusTransparencyEvent::QueryRequested(
+                        TransparencyQuery::CurrentObservation,
+                    )),
+                )
                 .await?;
             Ok(DispatchResult::Continue)
         }
@@ -1448,23 +1466,33 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
                 started_at: Instant::now(),
             });
             transport
-                .send(target, Event::Transparency(BusTransparencyEvent::QueryRequested(
-                    TransparencyQuery::UserMemory,
-                )))
+                .send(
+                    target,
+                    Event::Transparency(BusTransparencyEvent::QueryRequested(
+                        TransparencyQuery::UserMemory,
+                    )),
+                )
                 .await?;
             Ok(DispatchResult::Continue)
         }
         "/explanation" | "/why" => {
-            add_message(deps.state, MessageRole::System, "Querying last inference...");
+            add_message(
+                deps.state,
+                MessageRole::System,
+                "Querying last inference...",
+            );
             deps.command_state.transparency_loading = true;
             deps.command_state.pending_transparency = Some(PendingTransparencyQuery {
                 query: TransparencyQuery::InferenceExplanation,
                 started_at: Instant::now(),
             });
             transport
-                .send(target, Event::Transparency(BusTransparencyEvent::QueryRequested(
-                    TransparencyQuery::InferenceExplanation,
-                )))
+                .send(
+                    target,
+                    Event::Transparency(BusTransparencyEvent::QueryRequested(
+                        TransparencyQuery::InferenceExplanation,
+                    )),
+                )
                 .await?;
             Ok(DispatchResult::Continue)
         }
@@ -1476,7 +1504,11 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
         }
         "/verbose" => {
             deps.command_state.verbose = !deps.command_state.verbose;
-            let status = if deps.command_state.verbose { "ON" } else { "OFF" };
+            let status = if deps.command_state.verbose {
+                "ON"
+            } else {
+                "OFF"
+            };
             add_message(
                 deps.state,
                 MessageRole::System,
@@ -1496,8 +1528,16 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
             }
 
             deps.command_state.voice_enabled = !deps.command_state.voice_enabled;
-            let state = if deps.command_state.voice_enabled { "ON" } else { "OFF" };
-            add_message(deps.state, MessageRole::System, &format!("VOICE: {}", state));
+            let state = if deps.command_state.voice_enabled {
+                "ON"
+            } else {
+                "OFF"
+            };
+            add_message(
+                deps.state,
+                MessageRole::System,
+                &format!("VOICE: {}", state),
+            );
             add_message(
                 deps.state,
                 MessageRole::System,
@@ -1506,12 +1546,8 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
             Ok(DispatchResult::Continue)
         }
         "/speech" => {
-            show_speech_config_shared(
-                deps.runtime,
-                deps.state,
-                deps.command_state.voice_enabled,
-            )
-            .await;
+            show_speech_config_shared(deps.runtime, deps.state, deps.command_state.voice_enabled)
+                .await;
             Ok(DispatchResult::Continue)
         }
         "/listen" => {
@@ -1519,11 +1555,16 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
                 let session_id = deps.state.listen_session_id;
                 deps.state.listen_mode_active = false;
                 transport
-                    .send(target, Event::Speech(SpeechEvent::ListenModeStopRequested {
-                        session_id,
-                    }))
+                    .send(
+                        target,
+                        Event::Speech(SpeechEvent::ListenModeStopRequested { session_id }),
+                    )
                     .await?;
-                add_message(deps.state, MessageRole::System, "🎤 Stopping listen mode...");
+                add_message(
+                    deps.state,
+                    MessageRole::System,
+                    "🎤 Stopping listen mode...",
+                );
             } else {
                 let speech_enabled = load_speech_enabled(deps.runtime).await?;
                 if !speech_enabled {
@@ -1542,9 +1583,10 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
                 deps.state.listen_mode_active = true;
                 let session_id = deps.state.listen_session_id;
                 transport
-                    .send(target, Event::Speech(SpeechEvent::ListenModeRequested {
-                        session_id,
-                    }))
+                    .send(
+                        target,
+                        Event::Speech(SpeechEvent::ListenModeRequested { session_id }),
+                    )
                     .await?;
                 add_message(
                     deps.state,
@@ -1585,7 +1627,10 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
         "/close" | "/quit" | "/exit" | "/q" => Ok(DispatchResult::Close),
         "/shutdown" => {
             transport
-                .send(target, Event::System(bus::events::SystemEvent::ShutdownSignal))
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::ShutdownSignal),
+                )
                 .await?;
             Ok(DispatchResult::Shutdown)
         }
@@ -1600,34 +1645,58 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
     }
 }
 
-fn add_message(state: &mut crate::tui_state::ShellState<SlashDropdown>, role: MessageRole, text: &str) {
+fn add_message(
+    state: &mut crate::tui_state::ShellState<SlashDropdown>,
+    role: MessageRole,
+    text: &str,
+) {
     state.messages.push(Message::new(role, text.to_string()));
 }
 
 fn event_to_ipc_payload(event: &Event) -> Result<IpcPayload> {
     match event {
-        Event::Transparency(BusTransparencyEvent::QueryRequested(TransparencyQuery::CurrentObservation)) => {
-            Ok(IpcPayload::SlashCommand { line: "/observation".to_string() })
+        Event::Transparency(BusTransparencyEvent::QueryRequested(
+            TransparencyQuery::CurrentObservation,
+        )) => Ok(IpcPayload::SlashCommand {
+            line: "/observation".to_string(),
+        }),
+        Event::Transparency(BusTransparencyEvent::QueryRequested(
+            TransparencyQuery::UserMemory,
+        )) => Ok(IpcPayload::SlashCommand {
+            line: "/memory".to_string(),
+        }),
+        Event::Transparency(BusTransparencyEvent::QueryRequested(
+            TransparencyQuery::InferenceExplanation,
+        )) => Ok(IpcPayload::SlashCommand {
+            line: "/explanation".to_string(),
+        }),
+        Event::Speech(SpeechEvent::ListenModeRequested { session_id }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!("/listen start {}", session_id),
+            })
         }
-        Event::Transparency(BusTransparencyEvent::QueryRequested(TransparencyQuery::UserMemory)) => {
-            Ok(IpcPayload::SlashCommand { line: "/memory".to_string() })
+        Event::Speech(SpeechEvent::ListenModeStopRequested { session_id }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!("/listen stop {}", session_id),
+            })
         }
-        Event::Transparency(BusTransparencyEvent::QueryRequested(TransparencyQuery::InferenceExplanation)) => {
-            Ok(IpcPayload::SlashCommand { line: "/explanation".to_string() })
+        Event::System(bus::events::SystemEvent::ConfigSetRequested { key, value }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!("/config set {} {}", key, value),
+            })
         }
-        Event::Speech(SpeechEvent::ListenModeRequested { session_id }) => Ok(IpcPayload::SlashCommand {
-            line: format!("/listen start {}", session_id),
-        }),
-        Event::Speech(SpeechEvent::ListenModeStopRequested { session_id }) => Ok(IpcPayload::SlashCommand {
-            line: format!("/listen stop {}", session_id),
-        }),
-        Event::System(bus::events::SystemEvent::ConfigSetRequested { key, value }) => Ok(IpcPayload::SlashCommand {
-            line: format!("/config set {} {}", key, value),
-        }),
-        Event::System(bus::events::SystemEvent::LoopControlRequested { loop_name, enabled }) => Ok(IpcPayload::SlashCommand {
-            line: format!("/loops {} {}", loop_name, if *enabled { "on" } else { "off" }),
-        }),
-        Event::System(bus::events::SystemEvent::ShutdownSignal) => Ok(IpcPayload::ShutdownRequested),
+        Event::System(bus::events::SystemEvent::LoopControlRequested { loop_name, enabled }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!(
+                    "/loops {} {}",
+                    loop_name,
+                    if *enabled { "on" } else { "off" }
+                ),
+            })
+        }
+        Event::System(bus::events::SystemEvent::ShutdownSignal) => {
+            Ok(IpcPayload::ShutdownRequested)
+        }
         _ => Err(anyhow::anyhow!("event cannot be sent over IPC target")),
     }
 }
@@ -1643,7 +1712,8 @@ async fn current_models_dir(runtime: Option<&Runtime>) -> Result<PathBuf> {
         }
     }
 
-    runtime::ollama_models_dir().map_err(|e| anyhow::anyhow!("Could not resolve models directory: {}", e))
+    runtime::ollama_models_dir()
+        .map_err(|e| anyhow::anyhow!("Could not resolve models directory: {}", e))
 }
 
 async fn load_speech_enabled(runtime: Option<&Runtime>) -> Result<bool> {
@@ -1699,7 +1769,10 @@ async fn show_speech_config_shared(
     add_message(
         state,
         MessageRole::System,
-        &format!("voice_always_listening    {}", config.voice_always_listening),
+        &format!(
+            "voice_always_listening    {}",
+            config.voice_always_listening
+        ),
     );
     add_message(
         state,
@@ -1722,7 +1795,10 @@ async fn show_speech_config_shared(
     add_message(
         state,
         MessageRole::System,
-        &format!("voice_session_active      {}", if voice_enabled { "yes" } else { "no" }),
+        &format!(
+            "voice_session_active      {}",
+            if voice_enabled { "yes" } else { "no" }
+        ),
     );
 }
 
@@ -1754,7 +1830,11 @@ async fn show_screenshot_status_shared(
         MessageRole::System,
         &format!(
             "Screenshot capture: {} | Platform: {} | Active model: {} | Vision capable: {}",
-            if capture_enabled { "enabled" } else { "disabled" },
+            if capture_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
             platform_support,
             active_model,
             vision_status
@@ -1781,12 +1861,19 @@ async fn handle_microphone_command<T: MessageTransport + ?Sized>(
             .map_err(|_| anyhow::anyhow!("Usage: /microphone select <index>"))?;
         let devices = runtime::list_input_devices();
         if let Some((_, name)) = devices.into_iter().find(|(i, _)| *i == idx) {
-            let value = if idx == 0 { String::new() } else { name.clone() };
+            let value = if idx == 0 {
+                String::new()
+            } else {
+                name.clone()
+            };
             transport
-                .send(target, Event::System(bus::events::SystemEvent::ConfigSetRequested {
-                    key: "microphone_device".to_string(),
-                    value,
-                }))
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::ConfigSetRequested {
+                        key: "microphone_device".to_string(),
+                        value,
+                    }),
+                )
                 .await?;
             add_message(
                 state,
@@ -1801,7 +1888,10 @@ async fn handle_microphone_command<T: MessageTransport + ?Sized>(
             add_message(
                 state,
                 MessageRole::Warning,
-                &format!("No device at index {}. Run /microphone to list devices.", idx),
+                &format!(
+                    "No device at index {}. Run /microphone to list devices.",
+                    idx
+                ),
             );
         }
     } else {
@@ -1811,7 +1901,11 @@ async fn handle_microphone_command<T: MessageTransport + ?Sized>(
             add_message(state, MessageRole::Warning, "No input devices found.");
         } else {
             for (idx, name) in &devices {
-                add_message(state, MessageRole::System, &format!("  [{}]  {}", idx, name));
+                add_message(
+                    state,
+                    MessageRole::System,
+                    &format!("  [{}]  {}", idx, name),
+                );
             }
             add_message(
                 state,
@@ -1838,10 +1932,13 @@ async fn handle_config_command<T: MessageTransport + ?Sized>(
             String::new()
         };
         transport
-            .send(target, Event::System(bus::events::SystemEvent::ConfigSetRequested {
-                key: key.to_string(),
-                value: value.clone(),
-            }))
+            .send(
+                target,
+                Event::System(bus::events::SystemEvent::ConfigSetRequested {
+                    key: key.to_string(),
+                    value: value.clone(),
+                }),
+            )
             .await?;
         add_message(
             state,
@@ -1855,7 +1952,11 @@ async fn handle_config_command<T: MessageTransport + ?Sized>(
         let config = runtime::config::load_or_create_config().await?;
 
         add_message(state, MessageRole::System, "━━  Configuration");
-        add_message(state, MessageRole::System, &format!("Config file: {}", config_path));
+        add_message(
+            state,
+            MessageRole::System,
+            &format!("Config file: {}", config_path),
+        );
         match toml::to_string_pretty(&config) {
             Ok(toml_str) => {
                 for line in toml_str.lines() {
@@ -1896,17 +1997,24 @@ async fn handle_loops_command<T: MessageTransport + ?Sized>(
                 add_message(
                     state,
                     MessageRole::System,
-                    &format!("  {} — {}", label, if enabled { "enabled" } else { "disabled" }),
+                    &format!(
+                        "  {} — {}",
+                        label,
+                        if enabled { "enabled" } else { "disabled" }
+                    ),
                 );
             }
         }
         ["/loops", name] => {
             let enabled = !state.loop_states.get(*name).copied().unwrap_or(true);
             transport
-                .send(target, Event::System(bus::events::SystemEvent::LoopControlRequested {
-                    loop_name: (*name).to_string(),
-                    enabled,
-                }))
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::LoopControlRequested {
+                        loop_name: (*name).to_string(),
+                        enabled,
+                    }),
+                )
                 .await?;
             add_message(
                 state,
@@ -1928,10 +2036,13 @@ async fn handle_loops_command<T: MessageTransport + ?Sized>(
                 }
             };
             transport
-                .send(target, Event::System(bus::events::SystemEvent::LoopControlRequested {
-                    loop_name: (*name).to_string(),
-                    enabled,
-                }))
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::LoopControlRequested {
+                        loop_name: (*name).to_string(),
+                        enabled,
+                    }),
+                )
                 .await?;
             add_message(
                 state,
@@ -1978,7 +2089,10 @@ fn show_help_shared(state: &mut crate::tui_state::ShellState<SlashDropdown>) {
 fn show_actors_shared(state: &mut crate::tui_state::ShellState<SlashDropdown>) {
     add_message(state, MessageRole::System, "━━  Actor Status");
     for name in ["Platform", "Inference", "CTP", "Memory", "Soul"] {
-        let status = state.actor_health.get(name).unwrap_or(&ActorStatus::Starting);
+        let status = state
+            .actor_health
+            .get(name)
+            .unwrap_or(&ActorStatus::Starting);
         let text = match status {
             ActorStatus::Ready => "Ready".to_string(),
             ActorStatus::Starting => "Starting".to_string(),
@@ -2234,7 +2348,9 @@ fn transparency_timeout_message(query: &TransparencyQuery) -> String {
 #[allow(dead_code)]
 fn verbose_format(ev: &Event) -> Option<String> {
     match ev {
-        Event::CTP(bus::events::CTPEvent::ThoughtEventTriggered(_)) => {
+        Event::CTP(ctp_event)
+            if matches!(**ctp_event, bus::events::CTPEvent::ThoughtEventTriggered(_)) =>
+        {
             Some("[verbose] CTP: thought triggered".to_string())
         }
         Event::Soul(bus::events::SoulEvent::EventLogged(e)) => {
@@ -2294,7 +2410,7 @@ pub async fn run_with_ipc() -> anyhow::Result<()> {
     let mut state = crate::tui_state::ShellState::new();
     state.add_welcome_message("Connected to Sena daemon — local-first ambient AI");
     state.add_welcome_message("Type /help for commands, or chat freely.");
-    
+
     // Seed current_model from SessionReady handshake.
     state.current_model = initial_model;
 
@@ -2320,7 +2436,10 @@ pub async fn run_with_ipc() -> anyhow::Result<()> {
 }
 
 enum ShellMode {
-    Local { runtime: Arc<Runtime>, shell: Shell },
+    Local {
+        runtime: Arc<Runtime>,
+        shell: Shell,
+    },
     Ipc {
         state: crate::tui_state::ShellState<SlashDropdown>,
         command_state: CommandRuntimeState,
@@ -2402,7 +2521,9 @@ impl ShellMode {
                         }
                     }
                 } else {
-                    state.messages.push(Message::new(MessageRole::User, line.to_string()));
+                    state
+                        .messages
+                        .push(Message::new(MessageRole::User, line.to_string()));
                     let request_id = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .map(|d| d.as_nanos() as u64)
@@ -2433,7 +2554,10 @@ impl ShellMode {
         match self {
             Self::Local { shell, .. } => {
                 if let DisplayMessage::BusEvent(event) = message {
-                    if matches!(*event, Event::System(bus::events::SystemEvent::ShutdownSignal)) {
+                    if matches!(
+                        *event,
+                        Event::System(bus::events::SystemEvent::ShutdownSignal)
+                    ) {
                         tracing::info!("cli: ShutdownSignal received on bus — exiting shell");
                         return Some(ShellExitReason::Shutdown);
                     }
@@ -2471,9 +2595,10 @@ impl ShellMode {
                         IpcPayload::Pong | IpcPayload::Ack { .. } => {}
                         IpcPayload::Error { reason, .. } => {
                             state.waiting_for_inference = false;
-                            state
-                                .messages
-                                .push(Message::new(MessageRole::Warning, format!("Error: {}", reason)));
+                            state.messages.push(Message::new(
+                                MessageRole::Warning,
+                                format!("Error: {}", reason),
+                            ));
                         }
                         IpcPayload::LoopStatusUpdate { loop_name, enabled } => {
                             state.loop_states.insert(loop_name, enabled);
@@ -2521,7 +2646,10 @@ impl ShellMode {
                 config.preferred_model = Some(model_name.clone());
                 match runtime::save_config(&config).await {
                     Ok(_) => {
-                        shell.add_message(MessageRole::System, format!("Selected model: {}", model_name));
+                        shell.add_message(
+                            MessageRole::System,
+                            format!("Selected model: {}", model_name),
+                        );
                         shell.add_message(
                             MessageRole::System,
                             "Model change will take effect after restart.".to_string(),
@@ -2579,7 +2707,11 @@ async fn run_shell<T: MessageTransport>(
 
     'main: loop {
         if let Err(e) = terminal.draw(|f| mode.render(f)) {
-            add_message(mode.state_mut(), MessageRole::Warning, &format!("Display error: {}", e));
+            add_message(
+                mode.state_mut(),
+                MessageRole::Warning,
+                &format!("Display error: {}", e),
+            );
         }
 
         if let Some(first_press) = mode.state().ctrl_c_first_press {
@@ -2823,10 +2955,7 @@ async fn run_shell<T: MessageTransport>(
 }
 
 /// Simplified TUI rendering for IPC mode.
-fn render_ipc_tui(
-    frame: &mut ratatui::Frame,
-    state: &crate::tui_state::ShellState<SlashDropdown>,
-) {
+fn render_ipc_tui(frame: &mut ratatui::Frame, state: &crate::tui_state::ShellState<SlashDropdown>) {
     // ── Vertical layout: header / body / input ────────────────────────────────
     let main_chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -2967,11 +3096,7 @@ fn render_ipc_tui(
     frame.render_widget(paragraph, body_chunks[0]);
 
     // ── Sidebar ───────────────────────────────────────────────────────────────────
-    render_ipc_sidebar(
-        frame,
-        body_chunks[1],
-        state,
-    );
+    render_ipc_sidebar(frame, body_chunks[1], state);
 
     // Input area
     let prompt_line = Line::from(vec![
@@ -3121,7 +3246,10 @@ fn render_ipc_sidebar(
     )));
     let actor_names = ["Platform", "Inference", "CTP", "Memory", "Soul"];
     for name in &actor_names {
-        let status = state.actor_health.get(name).unwrap_or(&ActorStatus::Starting);
+        let status = state
+            .actor_health
+            .get(name)
+            .unwrap_or(&ActorStatus::Starting);
         let (dot, color, label) = match status {
             ActorStatus::Ready => ("\u{25cf}", Color::Green, "Ready"),
             ActorStatus::Starting => ("\u{25cb}", Color::Yellow, "Starting"),

--- a/crates/cli/src/tui_state.rs
+++ b/crates/cli/src/tui_state.rs
@@ -230,10 +230,8 @@ impl<T> ShellState<T> {
 
     /// Add a welcome message to the conversation log.
     pub fn add_welcome_message(&mut self, text: &str) {
-        self.messages.push(Message::new(
-            MessageRole::System,
-            text.to_string(),
-        ));
+        self.messages
+            .push(Message::new(MessageRole::System, text.to_string()));
     }
 }
 

--- a/crates/ctp/src/actor.rs
+++ b/crates/ctp/src/actor.rs
@@ -182,14 +182,14 @@ impl Actor for CTPActor {
 
                     // Emit ContextSnapshotReady event on each tick so downstream
                     // actors can observe context evolution even when no trigger fires.
-                    bus.broadcast(Event::CTP(CTPEvent::ContextSnapshotReady(snapshot.clone())))
+                    bus.broadcast(Event::CTP(Box::new(CTPEvent::ContextSnapshotReady(snapshot.clone()))))
                         .await
                         .map_err(|e| ActorError::RuntimeError(format!("failed to broadcast ContextSnapshotReady: {}", e)))?;
 
                     // Check if we should trigger
                     if self.boot_complete && self.gate.should_trigger(&snapshot) {
                         // Emit ThoughtEventTriggered event
-                        bus.broadcast(Event::CTP(CTPEvent::ThoughtEventTriggered(snapshot)))
+                        bus.broadcast(Event::CTP(Box::new(CTPEvent::ThoughtEventTriggered(snapshot))))
                             .await
                             .map_err(|e| ActorError::RuntimeError(format!("failed to broadcast ThoughtEventTriggered: {}", e)))?;
                     }
@@ -278,7 +278,7 @@ impl CTPActor {
         let response = handle_current_observation(self.refresh_snapshot());
 
         bus.broadcast(Event::Transparency(
-            TransparencyEvent::ObservationResponded(response),
+            TransparencyEvent::ObservationResponded(Box::new(response)),
         ))
         .await
         .map_err(|e| format!("failed to broadcast ObservationResponded: {}", e))

--- a/crates/ctp/src/context_assembler.rs
+++ b/crates/ctp/src/context_assembler.rs
@@ -2,7 +2,7 @@
 
 use std::time::{Duration, Instant};
 
-use bus::events::ctp::{ContextSnapshot, TaskHint};
+use bus::events::ctp::{ContextSnapshot, EnrichedInferredTask};
 use bus::events::platform::{KeystrokeCadence, WindowContext};
 
 use crate::signal_buffer::SignalBuffer;
@@ -97,6 +97,7 @@ impl ContextAssembler {
             keystroke_cadence,
             session_duration,
             inferred_task,
+            user_state: None,
             visual_context,
             timestamp: now,
         }
@@ -107,7 +108,7 @@ fn infer_task_hint(
     app_name: &str,
     window_title: Option<&str>,
     cadence: &KeystrokeCadence,
-) -> Option<TaskHint> {
+) -> Option<EnrichedInferredTask> {
     let app = app_name.to_lowercase();
     let title = window_title.unwrap_or_default().to_lowercase();
 
@@ -142,8 +143,17 @@ fn infer_task_hint(
         confidence += 0.05;
     }
 
-    Some(TaskHint {
+    let semantic_description = match category {
+        "coding" => format!("Writing code in {}", app_name),
+        "research" => format!("Researching in {}", app_name),
+        "writing" => format!("Writing in {}", app_name),
+        "operations" => format!("Running commands in {}", app_name),
+        _ => format!("Working in {}", app_name),
+    };
+
+    Some(EnrichedInferredTask {
         category: category.to_owned(),
+        semantic_description,
         confidence: confidence.min(0.95) as f32,
     })
 }
@@ -157,7 +167,7 @@ impl Default for ContextAssembler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bus::events::ctp::TaskHint;
+    use bus::events::ctp::EnrichedInferredTask;
     use bus::events::platform::{ClipboardDigest, FileEvent, FileEventKind, WindowContext};
     use std::path::PathBuf;
     use std::thread::sleep;
@@ -288,10 +298,12 @@ mod tests {
                 timestamp: Instant::now(),
             },
             session_duration: Duration::from_secs(30),
-            inferred_task: Some(TaskHint {
+            inferred_task: Some(EnrichedInferredTask {
                 category: "coding".to_string(),
+                semantic_description: "Writing code".to_string(),
                 confidence: 0.8,
             }),
+            user_state: None,
             visual_context: None,
             timestamp: Instant::now(),
         };

--- a/crates/ctp/src/ctp_actor.rs
+++ b/crates/ctp/src/ctp_actor.rs
@@ -184,14 +184,14 @@ impl Actor for CTPActor {
 
                     // Emit ContextSnapshotReady event on each tick so downstream
                     // actors can observe context evolution even when no trigger fires.
-                    bus.broadcast(Event::CTP(CTPEvent::ContextSnapshotReady(snapshot.clone())))
+                    bus.broadcast(Event::CTP(Box::new(CTPEvent::ContextSnapshotReady(snapshot.clone()))))
                         .await
                         .map_err(|e| ActorError::RuntimeError(format!("failed to broadcast ContextSnapshotReady: {}", e)))?;
 
                     // Check if we should trigger
                     if self.boot_complete && self.gate.should_trigger(&snapshot) {
                         // Emit ThoughtEventTriggered event
-                        bus.broadcast(Event::CTP(CTPEvent::ThoughtEventTriggered(snapshot)))
+                        bus.broadcast(Event::CTP(Box::new(CTPEvent::ThoughtEventTriggered(snapshot))))
                             .await
                             .map_err(|e| ActorError::RuntimeError(format!("failed to broadcast ThoughtEventTriggered: {}", e)))?;
                     }
@@ -280,7 +280,7 @@ impl CTPActor {
         let response = handle_current_observation(self.refresh_snapshot());
 
         bus.broadcast(Event::Transparency(
-            TransparencyEvent::ObservationResponded(response),
+            TransparencyEvent::ObservationResponded(Box::new(response)),
         ))
         .await
         .map_err(|e| format!("failed to broadcast ObservationResponded: {}", e))

--- a/crates/ctp/src/transparency_query.rs
+++ b/crates/ctp/src/transparency_query.rs
@@ -40,6 +40,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(5),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: Instant::now(),
         };

--- a/crates/ctp/src/trigger_gate.rs
+++ b/crates/ctp/src/trigger_gate.rs
@@ -143,7 +143,7 @@ fn context_diff_score(prev: &ContextSnapshot, current: &ContextSnapshot) -> f64 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bus::events::ctp::TaskHint;
+    use bus::events::ctp::EnrichedInferredTask;
     use bus::events::platform::{KeystrokeCadence, WindowContext};
     use std::thread::sleep;
 
@@ -166,6 +166,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(10),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }
@@ -237,13 +238,15 @@ mod tests {
     fn task_change_contributes_to_diff_score() {
         let mut gate = TriggerGate::new(Duration::from_secs(9999)).with_sensitivity(1.0);
         let mut first = snapshot("Code");
-        first.inferred_task = Some(TaskHint {
+        first.inferred_task = Some(EnrichedInferredTask {
             category: "coding".to_owned(),
+            semantic_description: "Writing code".to_string(),
             confidence: 0.8,
         });
         let mut second = snapshot("Code");
-        second.inferred_task = Some(TaskHint {
+        second.inferred_task = Some(EnrichedInferredTask {
             category: "research".to_owned(),
+            semantic_description: "Reading documentation".to_string(),
             confidence: 0.7,
         });
 

--- a/crates/inference/src/actor.rs
+++ b/crates/inference/src/actor.rs
@@ -372,12 +372,12 @@ impl InferenceActor {
                     None => return Err(err),
                 };
 
-                let retry_max_tokens = match Self::compute_retry_max_tokens(overflow, params.max_tokens)
-                {
-                    Ok(Some(v)) => v,
-                    Ok(None) => return Err(err),
-                    Err(e) => return Err(e.to_string()),
-                };
+                let retry_max_tokens =
+                    match Self::compute_retry_max_tokens(overflow, params.max_tokens) {
+                        Ok(Some(v)) => v,
+                        Ok(None) => return Err(err),
+                        Err(e) => return Err(e.to_string()),
+                    };
 
                 tracing::warn!(
                     "inference: context overflow on first attempt; retrying once with max_tokens {} -> {} (prompt={}, context={})",
@@ -1651,13 +1651,14 @@ impl Actor for InferenceActor {
                         Ok(Event::System(SystemEvent::ShutdownSignal)) => {
                             return Ok(());
                         }
-                        Ok(Event::CTP(CTPEvent::ContextSnapshotReady(snapshot))) => {
-                            self.last_snapshot = Some(snapshot);
-                        }
-                        Ok(Event::CTP(CTPEvent::ThoughtEventTriggered(snapshot))) => {
-                            // Proactive inference: CTP determined context is worth reasoning about.
-                            // Compose a context-derived prompt and run inference.
-                            self.last_snapshot = Some(snapshot.clone());
+                        Ok(Event::CTP(ctp_event)) => match *ctp_event {
+                            CTPEvent::ContextSnapshotReady(snapshot) => {
+                                self.last_snapshot = Some(snapshot);
+                            }
+                            CTPEvent::ThoughtEventTriggered(snapshot) => {
+                                // Proactive inference: CTP determined context is worth reasoning about.
+                                // Compose a context-derived prompt and run inference.
+                                self.last_snapshot = Some(snapshot.clone());
 
                             // Guard: only run proactive inference if the model is already loaded.
                             // Never call ensure_loaded() proactively — model loading is an
@@ -1717,7 +1718,9 @@ impl Actor for InferenceActor {
                                         .await;
                                 }
                             }
-                        }
+                            }
+                            _ => {} // Ignore other CTPEvent variants
+                        },
                         Ok(Event::Speech(SpeechEvent::TranscriptionCompleted {
                             text,
                             confidence: _,
@@ -2565,6 +2568,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(3600),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: Instant::now(),
         };
@@ -2601,6 +2605,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(1200),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: Instant::now(),
         };

--- a/crates/memory/src/working_memory.rs
+++ b/crates/memory/src/working_memory.rs
@@ -158,6 +158,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(0),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }

--- a/crates/prompt/src/composer.rs
+++ b/crates/prompt/src/composer.rs
@@ -122,6 +122,7 @@ mod tests {
             },
             session_duration: Duration::from_secs(3600),
             inferred_task: None,
+            user_state: None,
             visual_context: None,
             timestamp: now,
         }

--- a/crates/runtime/src/ipc_server.rs
+++ b/crates/runtime/src/ipc_server.rs
@@ -1002,7 +1002,12 @@ fn event_to_display_line(event: &Event) -> Option<IpcMessage> {
                 style: LineStyle::Error,
             },
         }),
-        Event::CTP(bus::events::ctp::CTPEvent::ThoughtEventTriggered(_thought)) => {
+        Event::CTP(ctp_event)
+            if matches!(
+                **ctp_event,
+                bus::events::ctp::CTPEvent::ThoughtEventTriggered(_)
+            ) =>
+        {
             // Only show in verbose mode (CLI-managed state).
             None
         }

--- a/crates/soul/src/actor.rs
+++ b/crates/soul/src/actor.rs
@@ -15,9 +15,13 @@ use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinSet;
 
 use crate::{
+    distillation::DistillationEngine,
     encrypted_db::EncryptedDb,
     error::SoulError,
+    preference_learning::PreferenceLearner,
     schema::{self, EVENT_LOG, IDENTITY_SIGNALS, USER_IDENTITY},
+    summary_assembler::SummaryAssembler,
+    temporal_model::TemporalModel,
 };
 
 const SOUL_ACTOR_NAME: &str = "soul";
@@ -33,6 +37,14 @@ pub struct SoulActor {
     broadcast_rx: Option<broadcast::Receiver<Event>>,
     directed_rx: Option<mpsc::Receiver<Event>>,
     task_set: JoinSet<()>,
+    /// Identity signal distillation engine.
+    distillation: DistillationEngine,
+    /// Temporal behavior model.
+    temporal: TemporalModel,
+    /// Preference learner.
+    preference_learner: PreferenceLearner,
+    /// Event absorption counter for periodic harvesting.
+    absorbed_event_count: u64,
 }
 
 impl SoulActor {
@@ -46,6 +58,10 @@ impl SoulActor {
             broadcast_rx: None,
             directed_rx: None,
             task_set: JoinSet::new(),
+            distillation: DistillationEngine::new(),
+            temporal: TemporalModel::new(),
+            preference_learner: PreferenceLearner::new(),
+            absorbed_event_count: 0,
         }
     }
 
@@ -310,11 +326,14 @@ impl SoulActor {
         Ok(())
     }
 
-    fn absorb_platform_signal(&self, event: PlatformEvent) -> Result<(), SoulError> {
+    fn absorb_platform_signal(&mut self, event: PlatformEvent) -> Result<(), SoulError> {
         match event {
             PlatformEvent::WindowChanged(window) => {
                 let key = format!("tool_pref::{}", window.app_name.to_lowercase());
                 self.increment_identity_counter(&key, 1)?;
+                // Record temporal event (use SystemTime::now() for calendar time)
+                self.temporal
+                    .record_event(std::time::SystemTime::now(), "window_change");
             }
             PlatformEvent::FileEvent(file) => {
                 if let Some(ext) = file.path.extension().and_then(|e| e.to_str()) {
@@ -332,10 +351,11 @@ impl SoulActor {
             }
             PlatformEvent::ClipboardChanged(_) => {}
         }
+        self.absorbed_event_count += 1;
         Ok(())
     }
 
-    fn absorb_ctp_signal(&self, event: CTPEvent) -> Result<(), SoulError> {
+    fn absorb_ctp_signal(&mut self, event: CTPEvent) -> Result<(), SoulError> {
         match event {
             CTPEvent::ContextSnapshotReady(snapshot) => {
                 if let Some(task) = snapshot.inferred_task {
@@ -345,6 +365,8 @@ impl SoulActor {
             }
             CTPEvent::ThoughtEventTriggered(_) => {
                 self.increment_identity_counter("ctp::thought_trigger_count", 1)?;
+                self.temporal
+                    .record_event(std::time::SystemTime::now(), "inference_triggered");
             }
             CTPEvent::UserStateComputed(user_state) => {
                 // Absorb user state signals for behavioral pattern analysis
@@ -361,20 +383,24 @@ impl SoulActor {
                 self.increment_identity_counter(&key, 1)?;
             }
         }
+        self.absorbed_event_count += 1;
         Ok(())
     }
 
-    fn absorb_inference_signal(&self, event: InferenceEvent) -> Result<(), SoulError> {
+    fn absorb_inference_signal(&mut self, event: InferenceEvent) -> Result<(), SoulError> {
         if let InferenceEvent::InferenceCompleted { text, .. } = event {
             for topic in infer_interest_topics(&text) {
                 let key = format!("interest::{}", topic);
                 self.increment_identity_counter(&key, 1)?;
             }
+            self.temporal
+                .record_event(std::time::SystemTime::now(), "inference_completed");
         }
+        self.absorbed_event_count += 1;
         Ok(())
     }
 
-    fn absorb_system_signal(&self, event: SystemEvent) -> Result<(), SoulError> {
+    fn absorb_system_signal(&mut self, event: SystemEvent) -> Result<(), SoulError> {
         match event {
             SystemEvent::FirstBoot => {
                 self.increment_identity_counter("system::first_boot_count", 1)?;
@@ -387,6 +413,7 @@ impl SoulActor {
             }
             _ => {}
         }
+        self.absorbed_event_count += 1;
         Ok(())
     }
 
@@ -458,6 +485,116 @@ impl SoulActor {
                 })))
                 .await;
         });
+        Ok(())
+    }
+
+    /// Handle RichSummaryRequested event.
+    fn handle_rich_summary_requested(
+        &mut self,
+        token_budget: usize,
+        request_id: u64,
+        bus: &Arc<EventBus>,
+    ) -> Result<(), SoulError> {
+        let db = self
+            .db
+            .as_ref()
+            .ok_or_else(|| SoulError::Database("not initialized".into()))?;
+        let redb = db.db()?;
+
+        let mut summary = SummaryAssembler::assemble(redb, token_budget)?;
+        summary.request_id = request_id;
+
+        let bus_clone = Arc::clone(bus);
+        self.task_set.spawn(async move {
+            let _ = bus_clone
+                .broadcast(Event::Soul(SoulEvent::RichSummaryReady(summary)))
+                .await;
+        });
+
+        Ok(())
+    }
+
+    /// Handle PreferenceLearningUpdate event.
+    fn handle_preference_learning_update(
+        &mut self,
+        signal: &bus::events::soul::EngagementSignal,
+        bus: &Arc<EventBus>,
+    ) -> Result<(), SoulError> {
+        self.preference_learner.record_engagement(signal);
+        self.maybe_harvest_intelligence(bus)?;
+        Ok(())
+    }
+
+    /// Periodically harvest distilled signals and preferences.
+    ///
+    /// Called after every N absorbed events or explicitly after preference updates.
+    fn maybe_harvest_intelligence(&mut self, bus: &Arc<EventBus>) -> Result<(), SoulError> {
+        // Harvest every 50 absorbed events
+        if self.absorbed_event_count < 50 {
+            return Ok(());
+        }
+
+        // Load current identity signals into distillation engine
+        if let Some(db) = &self.db {
+            let redb = db.db()?;
+            let signals = read_identity_signals(redb)?;
+            for (key, value) in signals {
+                self.distillation.observe_identity_signal(&key, &value);
+            }
+        }
+
+        // Harvest distilled signals
+        let distilled_signals = self.distillation.harvest();
+        for signal in distilled_signals {
+            // Persist to IDENTITY_SIGNALS
+            self.write_identity_signal(&signal.signal_key, &signal.signal_value)?;
+            // Broadcast event
+            let bus_clone = Arc::clone(bus);
+            let signal_clone = signal.clone();
+            self.task_set.spawn(async move {
+                let _ = bus_clone
+                    .broadcast(Event::Soul(SoulEvent::IdentitySignalDistilled(
+                        signal_clone,
+                    )))
+                    .await;
+            });
+        }
+
+        // Harvest preferences
+        let preferences = self.preference_learner.harvest_preferences();
+        for (key, value) in preferences {
+            self.write_identity_signal(&key, &value)?;
+        }
+
+        // Harvest temporal patterns (top 10) and persist to IDENTITY_SIGNALS
+        let patterns = self.temporal.top_patterns(10);
+        for pattern in patterns {
+            if let (Some(hour), Some(day)) = (pattern.hour_of_day, pattern.day_of_week) {
+                let key = format!(
+                    "temporal::hour::{}::day::{}::{}",
+                    hour, day, pattern.behavior_category
+                );
+                self.write_identity_signal(&key, &pattern.frequency.to_string())?;
+
+                // Broadcast event
+                let bus_clone = Arc::clone(bus);
+                let pattern_clone = pattern.clone();
+                self.task_set.spawn(async move {
+                    let _ = bus_clone
+                        .broadcast(Event::Soul(SoulEvent::TemporalPatternDetected(
+                            pattern_clone,
+                        )))
+                        .await;
+                });
+            }
+        }
+
+        // Emit personality update after intelligence harvest
+        self.emit_personality_updated(bus)?;
+
+        // Reset counter
+        self.absorbed_event_count = 0;
+
         Ok(())
     }
 }
@@ -626,21 +763,27 @@ impl Actor for SoulActor {
                             if is_boot_complete {
                                 let _ = self.emit_personality_updated(&bus);
                             }
+                            let _ = self.maybe_harvest_intelligence(&bus);
                         }
                         Ok(Event::Platform(platform_event)) => {
                             let _ = self.absorb_platform_signal(platform_event);
+                            let _ = self.maybe_harvest_intelligence(&bus);
                         }
                         Ok(Event::CTP(ctp_event)) => {
                             let _ = self.absorb_ctp_signal(*ctp_event);
+                            let _ = self.maybe_harvest_intelligence(&bus);
                         }
                         Ok(Event::Inference(inference_event)) => {
                             let _ = self.absorb_inference_signal(inference_event);
+                            let _ = self.maybe_harvest_intelligence(&bus);
                         }
                         Ok(Event::Memory(MemoryEvent::ConsolidationCompleted(_))) => {
                             let _ = self.increment_identity_counter(
                                 "memory::consolidation_completed_count",
                                 1,
                             );
+                            self.absorbed_event_count += 1;
+                            let _ = self.maybe_harvest_intelligence(&bus);
                         }
                         Ok(Event::Soul(SoulEvent::ReadRequested(req))) => {
                             let _ = self.handle_read(req, &bus);
@@ -672,6 +815,12 @@ impl Actor for SoulActor {
                                 }
                                 SoulEvent::InitializeWithName { name } => {
                                     let _ = self.handle_initialize_with_name(name, &bus);
+                                }
+                                SoulEvent::RichSummaryRequested { token_budget, request_id } => {
+                                    let _ = self.handle_rich_summary_requested(token_budget, request_id, &bus);
+                                }
+                                SoulEvent::PreferenceLearningUpdate { signal, .. } => {
+                                    let _ = self.handle_preference_learning_update(&signal, &bus);
                                 }
                                 SoulEvent::ExportRequested { path } => {
                                     // TODO M6: implement full export (event log + identity signals → JSON).

--- a/crates/soul/src/actor.rs
+++ b/crates/soul/src/actor.rs
@@ -346,6 +346,20 @@ impl SoulActor {
             CTPEvent::ThoughtEventTriggered(_) => {
                 self.increment_identity_counter("ctp::thought_trigger_count", 1)?;
             }
+            CTPEvent::UserStateComputed(user_state) => {
+                // Absorb user state signals for behavioral pattern analysis
+                if user_state.flow_detected {
+                    self.increment_identity_counter("user_state::flow_state_count", 1)?;
+                }
+                if user_state.frustration_level > 70 {
+                    self.increment_identity_counter("user_state::high_frustration_count", 1)?;
+                }
+            }
+            CTPEvent::SignalPatternDetected(pattern) => {
+                // Absorb detected signal patterns for identity distillation
+                let key = format!("pattern::{:?}", pattern.pattern_type).to_lowercase();
+                self.increment_identity_counter(&key, 1)?;
+            }
         }
         Ok(())
     }
@@ -617,7 +631,7 @@ impl Actor for SoulActor {
                             let _ = self.absorb_platform_signal(platform_event);
                         }
                         Ok(Event::CTP(ctp_event)) => {
-                            let _ = self.absorb_ctp_signal(ctp_event);
+                            let _ = self.absorb_ctp_signal(*ctp_event);
                         }
                         Ok(Event::Inference(inference_event)) => {
                             let _ = self.absorb_inference_signal(inference_event);

--- a/crates/soul/src/distillation.rs
+++ b/crates/soul/src/distillation.rs
@@ -1,0 +1,184 @@
+//! Identity signal distillation: extract persistent patterns from counters.
+
+use bus::events::soul::DistilledIdentitySignal;
+use std::collections::HashMap;
+
+/// Distillation engine that watches identity signal counters and extracts
+/// persistent patterns when significance thresholds are crossed.
+pub(crate) struct DistillationEngine {
+    /// Accumulated observations: signal_key -> count.
+    observations: HashMap<String, u64>,
+    /// Total event count for computing proportions.
+    total_events: u64,
+    /// Minimum event count before a signal can be considered for distillation.
+    min_threshold: u64,
+}
+
+impl DistillationEngine {
+    pub(crate) fn new() -> Self {
+        Self {
+            observations: HashMap::new(),
+            total_events: 0,
+            min_threshold: 20,
+        }
+    }
+
+    /// Feed an identity signal observation to the engine.
+    pub(crate) fn observe_identity_signal(&mut self, key: &str, value: &str) {
+        // Only accumulate numeric counter values (these are the counters we distill)
+        if let Ok(count) = value.parse::<u64>() {
+            self.observations.insert(key.to_string(), count);
+            self.total_events = self.total_events.saturating_add(count);
+        }
+    }
+
+    /// Harvest any identity signals that have crossed significance thresholds.
+    ///
+    /// Returns signals ready to persist and broadcast.
+    /// Clears internal state after harvest (signals are now owned by caller).
+    pub(crate) fn harvest(&mut self) -> Vec<DistilledIdentitySignal> {
+        if self.total_events == 0 {
+            return Vec::new();
+        }
+
+        let mut signals = Vec::new();
+
+        // Distill tool preferences
+        let tool_prefs: Vec<_> = self
+            .observations
+            .iter()
+            .filter(|(k, _)| k.starts_with("tool_pref::"))
+            .map(|(k, v)| (k.clone(), *v))
+            .collect();
+
+        if let Some((top_tool_key, top_tool_count)) =
+            tool_prefs.iter().max_by_key(|(_, count)| *count)
+        {
+            if *top_tool_count >= self.min_threshold {
+                let tool_name = top_tool_key.trim_start_matches("tool_pref::");
+                let confidence = (*top_tool_count as f32) / (self.total_events as f32);
+                let confidence = confidence.min(1.0);
+                signals.push(DistilledIdentitySignal {
+                    signal_key: "frequent_app".to_string(),
+                    signal_value: tool_name.to_string(),
+                    confidence,
+                    source_event_count: *top_tool_count as u32,
+                });
+            }
+        }
+
+        // Distill interest clusters
+        for (key, count) in &self.observations {
+            if key.starts_with("interest::") && *count >= self.min_threshold {
+                let interest = key.trim_start_matches("interest::");
+                let confidence = (*count as f32) / (self.total_events as f32);
+                let confidence = confidence.clamp(0.5, 1.0); // Interests get min 0.5 confidence
+                signals.push(DistilledIdentitySignal {
+                    signal_key: format!("interest::{}", interest),
+                    signal_value: interest.to_string(),
+                    confidence,
+                    source_event_count: *count as u32,
+                });
+            }
+        }
+
+        // Distill work patterns
+        for (key, count) in &self.observations {
+            if key.starts_with("work_pattern::") && *count >= self.min_threshold {
+                let pattern = key.trim_start_matches("work_pattern::");
+                let confidence = (*count as f32) / (self.total_events as f32);
+                let confidence = confidence.clamp(0.6, 1.0);
+                signals.push(DistilledIdentitySignal {
+                    signal_key: format!("work_pattern::{}", pattern),
+                    signal_value: pattern.to_string(),
+                    confidence,
+                    source_event_count: *count as u32,
+                });
+            }
+        }
+
+        // Clear state after harvest
+        self.observations.clear();
+        self.total_events = 0;
+
+        signals
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distillation_below_threshold_produces_nothing() {
+        let mut engine = DistillationEngine::new();
+        engine.observe_identity_signal("tool_pref::code", "10");
+        engine.observe_identity_signal("tool_pref::browser", "5");
+
+        let signals = engine.harvest();
+        assert!(signals.is_empty());
+    }
+
+    #[test]
+    fn distillation_above_threshold_produces_signal() {
+        let mut engine = DistillationEngine::new();
+        engine.observe_identity_signal("tool_pref::code", "60");
+        engine.observe_identity_signal("tool_pref::browser", "30");
+        engine.observe_identity_signal("tool_pref::terminal", "10");
+
+        let signals = engine.harvest();
+        assert_eq!(signals.len(), 1);
+        assert_eq!(signals[0].signal_key, "frequent_app");
+        assert_eq!(signals[0].signal_value, "code");
+        assert!(signals[0].confidence > 0.5);
+        assert_eq!(signals[0].source_event_count, 60);
+    }
+
+    #[test]
+    fn distillation_extracts_multiple_signals() {
+        let mut engine = DistillationEngine::new();
+        engine.observe_identity_signal("tool_pref::code", "100");
+        engine.observe_identity_signal("interest::rust", "50");
+        engine.observe_identity_signal("interest::ai", "30");
+        engine.observe_identity_signal("work_pattern::high_cadence_count", "40");
+
+        let signals = engine.harvest();
+        // Should get: frequent_app, interest::rust, interest::ai, work_pattern::high_cadence_count
+        assert!(signals.len() >= 4);
+
+        let has_app = signals.iter().any(|s| s.signal_key == "frequent_app");
+        let has_rust = signals.iter().any(|s| s.signal_key == "interest::rust");
+        let has_ai = signals.iter().any(|s| s.signal_key == "interest::ai");
+        let has_cadence = signals
+            .iter()
+            .any(|s| s.signal_key == "work_pattern::high_cadence_count");
+
+        assert!(has_app);
+        assert!(has_rust);
+        assert!(has_ai);
+        assert!(has_cadence);
+    }
+
+    #[test]
+    fn harvest_clears_state() {
+        let mut engine = DistillationEngine::new();
+        engine.observe_identity_signal("tool_pref::code", "100");
+
+        let signals1 = engine.harvest();
+        assert_eq!(signals1.len(), 1);
+
+        // Second harvest should return empty (state was cleared)
+        let signals2 = engine.harvest();
+        assert!(signals2.is_empty());
+    }
+
+    #[test]
+    fn non_numeric_values_ignored() {
+        let mut engine = DistillationEngine::new();
+        engine.observe_identity_signal("tool_pref::code", "not_a_number");
+        engine.observe_identity_signal("tool_pref::browser", "also_not_number");
+
+        let signals = engine.harvest();
+        assert!(signals.is_empty());
+    }
+}

--- a/crates/soul/src/lib.rs
+++ b/crates/soul/src/lib.rs
@@ -6,6 +6,11 @@ pub mod error;
 pub mod redacted;
 pub mod schema;
 
+mod distillation;
+mod preference_learning;
+mod summary_assembler;
+mod temporal_model;
+
 pub use actor::SoulActor;
 pub use encrypted_db::EncryptedDb;
 pub use error::SoulError;

--- a/crates/soul/src/preference_learning.rs
+++ b/crates/soul/src/preference_learning.rs
@@ -1,0 +1,193 @@
+//! Preference learning: extract user preference from engagement signals.
+
+use bus::events::soul::EngagementSignal;
+
+/// Preference learner that accumulates engagement signals and distills
+/// user preferences once sufficient data is available.
+pub(crate) struct PreferenceLearner {
+    accepted_count: u32,
+    ignored_count: u32,
+    interrupted_count: u32,
+    follow_up_count: u32,
+    /// Minimum total signals before preferences are distilled.
+    min_signals: u32,
+}
+
+impl PreferenceLearner {
+    pub(crate) fn new() -> Self {
+        Self {
+            accepted_count: 0,
+            ignored_count: 0,
+            interrupted_count: 0,
+            follow_up_count: 0,
+            min_signals: 20,
+        }
+    }
+
+    /// Record an engagement signal.
+    pub(crate) fn record_engagement(&mut self, signal: &EngagementSignal) {
+        match signal {
+            EngagementSignal::Accepted => self.accepted_count += 1,
+            EngagementSignal::Ignored => self.ignored_count += 1,
+            EngagementSignal::Interrupted => self.interrupted_count += 1,
+            EngagementSignal::FollowUpQuery => self.follow_up_count += 1,
+        }
+    }
+
+    /// Harvest preference updates when sufficient data is accumulated.
+    ///
+    /// Returns (key, value) pairs to write to IDENTITY_SIGNALS.
+    /// Clears internal counters after harvest.
+    pub(crate) fn harvest_preferences(&mut self) -> Vec<(String, String)> {
+        let total = self.accepted_count
+            + self.ignored_count
+            + self.interrupted_count
+            + self.follow_up_count;
+
+        if total < self.min_signals {
+            return Vec::new();
+        }
+
+        let mut preferences = Vec::new();
+
+        // Verbosity preference: interrupted signals user wants shorter responses
+        let interrupted_ratio = (self.interrupted_count as f32) / (total as f32);
+        if interrupted_ratio >= 0.5 {
+            preferences.push(("preference::verbosity".to_string(), "low".to_string()));
+        } else if interrupted_ratio <= 0.2 {
+            preferences.push(("preference::verbosity".to_string(), "high".to_string()));
+        }
+
+        // Engagement preference: follow-up queries signal high engagement
+        let follow_up_ratio = (self.follow_up_count as f32) / (total as f32);
+        if follow_up_ratio >= 0.4 {
+            preferences.push(("preference::engagement".to_string(), "high".to_string()));
+        } else if follow_up_ratio <= 0.1 {
+            preferences.push(("preference::engagement".to_string(), "low".to_string()));
+        }
+
+        // Proactive preference: ignored signals user doesn't want proactive responses
+        let ignored_ratio = (self.ignored_count as f32) / (total as f32);
+        if ignored_ratio >= 0.6 {
+            preferences.push(("preference::proactive".to_string(), "low".to_string()));
+        } else if ignored_ratio <= 0.2 {
+            preferences.push(("preference::proactive".to_string(), "high".to_string()));
+        }
+
+        // Clear counters after harvest
+        self.accepted_count = 0;
+        self.ignored_count = 0;
+        self.interrupted_count = 0;
+        self.follow_up_count = 0;
+
+        preferences
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn learner_requires_minimum_signals() {
+        let mut learner = PreferenceLearner::new();
+        for _ in 0..10 {
+            learner.record_engagement(&EngagementSignal::Accepted);
+        }
+
+        let prefs = learner.harvest_preferences();
+        assert!(prefs.is_empty()); // Below min_signals threshold
+    }
+
+    #[test]
+    fn learner_distills_low_verbosity_from_interruptions() {
+        let mut learner = PreferenceLearner::new();
+
+        // 12 interrupted, 8 accepted → 60% interrupted
+        for _ in 0..12 {
+            learner.record_engagement(&EngagementSignal::Interrupted);
+        }
+        for _ in 0..8 {
+            learner.record_engagement(&EngagementSignal::Accepted);
+        }
+
+        let prefs = learner.harvest_preferences();
+        assert!(prefs
+            .iter()
+            .any(|(k, v)| k == "preference::verbosity" && v == "low"));
+    }
+
+    #[test]
+    fn learner_distills_high_engagement_from_follow_ups() {
+        let mut learner = PreferenceLearner::new();
+
+        // 10 follow-ups, 15 accepted → 40% follow-up
+        for _ in 0..10 {
+            learner.record_engagement(&EngagementSignal::FollowUpQuery);
+        }
+        for _ in 0..15 {
+            learner.record_engagement(&EngagementSignal::Accepted);
+        }
+
+        let prefs = learner.harvest_preferences();
+        assert!(prefs
+            .iter()
+            .any(|(k, v)| k == "preference::engagement" && v == "high"));
+    }
+
+    #[test]
+    fn learner_distills_low_proactive_from_ignored_signals() {
+        let mut learner = PreferenceLearner::new();
+
+        // 15 ignored, 10 accepted → 60% ignored
+        for _ in 0..15 {
+            learner.record_engagement(&EngagementSignal::Ignored);
+        }
+        for _ in 0..10 {
+            learner.record_engagement(&EngagementSignal::Accepted);
+        }
+
+        let prefs = learner.harvest_preferences();
+        assert!(prefs
+            .iter()
+            .any(|(k, v)| k == "preference::proactive" && v == "low"));
+    }
+
+    #[test]
+    fn harvest_clears_counters() {
+        let mut learner = PreferenceLearner::new();
+
+        for _ in 0..25 {
+            learner.record_engagement(&EngagementSignal::Accepted);
+        }
+
+        let prefs1 = learner.harvest_preferences();
+        assert!(!prefs1.is_empty());
+
+        // Second harvest should return empty (counters cleared)
+        let prefs2 = learner.harvest_preferences();
+        assert!(prefs2.is_empty());
+    }
+
+    #[test]
+    fn learner_distills_multiple_preferences() {
+        let mut learner = PreferenceLearner::new();
+
+        // 12 interrupted (low verbosity), 5 follow-ups (borderline engagement), 3 ignored
+        for _ in 0..12 {
+            learner.record_engagement(&EngagementSignal::Interrupted);
+        }
+        for _ in 0..5 {
+            learner.record_engagement(&EngagementSignal::FollowUpQuery);
+        }
+        for _ in 0..3 {
+            learner.record_engagement(&EngagementSignal::Ignored);
+        }
+
+        let prefs = learner.harvest_preferences();
+        // Should get verbosity=low (60% interrupted)
+        assert!(prefs
+            .iter()
+            .any(|(k, v)| k == "preference::verbosity" && v == "low"));
+    }
+}

--- a/crates/soul/src/summary_assembler.rs
+++ b/crates/soul/src/summary_assembler.rs
@@ -1,0 +1,331 @@
+//! Rich Soul summary assembly: multi-section structured summaries.
+
+use crate::error::SoulError;
+use crate::schema::{EVENT_LOG, IDENTITY_SIGNALS};
+use bus::events::soul::{RichSoulSummary, SoulSection, SoulSectionType};
+use redb::{ReadableDatabase, ReadableTable};
+
+/// Summary assembler that builds rich, structured Soul summaries.
+pub(crate) struct SummaryAssembler;
+
+impl SummaryAssembler {
+    /// Build a rich multi-section summary from Soul database state.
+    ///
+    /// `token_budget` limits total output size (rough estimate: 4 chars ≈ 1 token).
+    pub(crate) fn assemble(
+        db: &redb::Database,
+        token_budget: usize,
+    ) -> Result<RichSoulSummary, SoulError> {
+        let mut sections = Vec::new();
+
+        // Section 1: Recent events (relevance 0.6)
+        if let Ok(recent_events_content) = Self::read_recent_events(db, 50) {
+            if !recent_events_content.is_empty() {
+                sections.push(SoulSection {
+                    section_type: SoulSectionType::RecentEvents,
+                    content: recent_events_content,
+                    relevance_score: 0.6,
+                });
+            }
+        }
+
+        // Section 2: Identity signals (relevance 0.9)
+        if let Ok(identity_signals_content) = Self::read_identity_signals(db) {
+            if !identity_signals_content.is_empty() {
+                sections.push(SoulSection {
+                    section_type: SoulSectionType::IdentitySignals,
+                    content: identity_signals_content,
+                    relevance_score: 0.9,
+                });
+            }
+        }
+
+        // Section 3: Temporal patterns (relevance 0.7)
+        if let Ok(temporal_content) = Self::read_temporal_patterns(db) {
+            if !temporal_content.is_empty() {
+                sections.push(SoulSection {
+                    section_type: SoulSectionType::TemporalHabits,
+                    content: temporal_content,
+                    relevance_score: 0.7,
+                });
+            }
+        }
+
+        // Section 4: Preferences (relevance 0.8)
+        if let Ok(preferences_content) = Self::read_preferences(db) {
+            if !preferences_content.is_empty() {
+                sections.push(SoulSection {
+                    section_type: SoulSectionType::Preferences,
+                    content: preferences_content,
+                    relevance_score: 0.8,
+                });
+            }
+        }
+
+        // Sort by relevance (highest first)
+        sections.sort_by(|a, b| {
+            b.relevance_score
+                .partial_cmp(&a.relevance_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        // Apply token budget
+        let (final_sections, token_count) = Self::apply_token_budget(sections, token_budget);
+
+        Ok(RichSoulSummary {
+            sections: final_sections,
+            token_count,
+            request_id: 0, // Caller will set this
+        })
+    }
+
+    fn read_recent_events(db: &redb::Database, max_events: usize) -> Result<String, SoulError> {
+        let read_txn = db.begin_read()?;
+        let log = read_txn.open_table(EVENT_LOG)?;
+
+        let entries: Vec<String> = log
+            .iter()?
+            .rev()
+            .take(max_events)
+            .map(|r| {
+                let (_, v) = r?;
+                Ok(String::from_utf8_lossy(v.value()).into_owned())
+            })
+            .collect::<Result<Vec<_>, redb::StorageError>>()?;
+
+        Ok(entries.join("\n"))
+    }
+
+    fn read_identity_signals(db: &redb::Database) -> Result<String, SoulError> {
+        let read_txn = db.begin_read()?;
+        let table = read_txn.open_table(IDENTITY_SIGNALS)?;
+
+        let mut signals: Vec<String> = table
+            .iter()?
+            .filter_map(|entry| {
+                let (k, v) = entry.ok()?;
+                let key = k.value();
+                // Exclude temporal and preference keys (they have their own sections)
+                if key.starts_with("temporal::") || key.starts_with("preference::") {
+                    return None;
+                }
+                Some(format!("{}={}", key, v.value()))
+            })
+            .collect();
+
+        signals.sort();
+        Ok(signals.join("\n"))
+    }
+
+    fn read_temporal_patterns(db: &redb::Database) -> Result<String, SoulError> {
+        let read_txn = db.begin_read()?;
+        let table = read_txn.open_table(IDENTITY_SIGNALS)?;
+
+        let mut patterns: Vec<String> = table
+            .iter()?
+            .filter_map(|entry| {
+                let (k, v) = entry.ok()?;
+                let key = k.value();
+                if key.starts_with("temporal::") {
+                    Some(format!("{}={}", key, v.value()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        patterns.sort();
+        Ok(patterns.join("\n"))
+    }
+
+    fn read_preferences(db: &redb::Database) -> Result<String, SoulError> {
+        let read_txn = db.begin_read()?;
+        let table = read_txn.open_table(IDENTITY_SIGNALS)?;
+
+        let mut prefs: Vec<String> = table
+            .iter()?
+            .filter_map(|entry| {
+                let (k, v) = entry.ok()?;
+                let key = k.value();
+                if key.starts_with("preference::") {
+                    Some(format!("{}={}", key, v.value()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        prefs.sort();
+        Ok(prefs.join("\n"))
+    }
+
+    fn apply_token_budget(
+        mut sections: Vec<SoulSection>,
+        token_budget: usize,
+    ) -> (Vec<SoulSection>, usize) {
+        let char_budget = token_budget * 4; // Rough estimate: 4 chars ≈ 1 token
+        let mut total_chars = 0;
+        let mut kept_sections = Vec::new();
+
+        for section in sections.drain(..) {
+            let section_len = section.content.len();
+            if total_chars + section_len <= char_budget {
+                total_chars += section_len;
+                kept_sections.push(section);
+            } else {
+                // Truncate this section to fit remaining budget
+                let remaining = char_budget.saturating_sub(total_chars);
+                if remaining > 20 {
+                    // Only include if we can fit a meaningful chunk
+                    let truncate_at = section
+                        .content
+                        .char_indices()
+                        .map(|(i, _)| i)
+                        .nth(remaining.saturating_sub(14)) // Reserve space for suffix
+                        .unwrap_or(0);
+
+                    let mut truncated_content = section.content;
+                    truncated_content.truncate(truncate_at);
+                    truncated_content.push_str("...[truncated]");
+
+                    total_chars += truncated_content.len();
+                    kept_sections.push(SoulSection {
+                        section_type: section.section_type,
+                        content: truncated_content,
+                        relevance_score: section.relevance_score,
+                    });
+                }
+                break; // Budget exhausted
+            }
+        }
+
+        let token_count = total_chars / 4;
+        (kept_sections, token_count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::apply_schema;
+    use redb::{ReadableTable, TableDefinition};
+    use tempfile::tempdir;
+
+    fn open_test_db() -> (tempfile::TempDir, redb::Database) {
+        let dir = tempdir().expect("should create tempdir");
+        let db = redb::Database::create(dir.path().join("test.redb")).expect("should create db");
+        apply_schema(&db).expect("should apply schema");
+        (dir, db)
+    }
+
+    #[test]
+    fn assemble_empty_db_produces_empty_sections() {
+        let (_dir, db) = open_test_db();
+
+        let summary = SummaryAssembler::assemble(&db, 1000).expect("should assemble");
+        assert_eq!(summary.sections.len(), 0);
+    }
+
+    #[test]
+    fn assemble_populated_db_produces_ordered_sections() {
+        let (_dir, db) = open_test_db();
+
+        // Write some test data
+        {
+            let write_txn = db.begin_write().expect("should begin write");
+            {
+                let mut log = write_txn.open_table(EVENT_LOG).expect("should open log");
+                log.insert(1u64, "event 1".as_bytes())
+                    .expect("should insert");
+                log.insert(2u64, "event 2".as_bytes())
+                    .expect("should insert");
+            }
+            {
+                let mut signals = write_txn
+                    .open_table(IDENTITY_SIGNALS)
+                    .expect("should open signals");
+                signals
+                    .insert("tool_pref::code", "100")
+                    .expect("should insert");
+                signals
+                    .insert("temporal::hour::14::inference", "50")
+                    .expect("should insert");
+                signals
+                    .insert("preference::verbosity", "low")
+                    .expect("should insert");
+            }
+            write_txn.commit().expect("should commit");
+        }
+
+        let summary = SummaryAssembler::assemble(&db, 10000).expect("should assemble");
+
+        // Should have 4 sections
+        assert_eq!(summary.sections.len(), 4);
+
+        // Should be sorted by relevance (identity signals = 0.9 should be first)
+        assert!(matches!(
+            summary.sections[0].section_type,
+            SoulSectionType::IdentitySignals
+        ));
+    }
+
+    #[test]
+    fn token_budget_truncates_sections() {
+        let (_dir, db) = open_test_db();
+
+        // Write large content
+        {
+            let write_txn = db.begin_write().expect("should begin write");
+            {
+                let mut log = write_txn.open_table(EVENT_LOG).expect("should open log");
+                for i in 0..100 {
+                    let entry = format!("event {}", i);
+                    log.insert(i, entry.as_bytes()).expect("should insert");
+                }
+            }
+            write_txn.commit().expect("should commit");
+        }
+
+        // Small token budget (100 tokens = ~400 chars)
+        let summary = SummaryAssembler::assemble(&db, 100).expect("should assemble");
+
+        // Should have truncated content
+        let total_chars: usize = summary.sections.iter().map(|s| s.content.len()).sum();
+        assert!(total_chars <= 400);
+        assert!(summary.token_count <= 100);
+    }
+
+    #[test]
+    fn sections_are_sorted_by_relevance() {
+        let (_dir, db) = open_test_db();
+
+        {
+            let write_txn = db.begin_write().expect("should begin write");
+            {
+                let mut log = write_txn.open_table(EVENT_LOG).expect("should open log");
+                log.insert(1u64, "event".as_bytes()).expect("should insert");
+            }
+            {
+                let mut signals = write_txn
+                    .open_table(IDENTITY_SIGNALS)
+                    .expect("should open signals");
+                signals.insert("key", "value").expect("should insert");
+                signals
+                    .insert("preference::test", "high")
+                    .expect("should insert");
+                signals
+                    .insert("temporal::hour::12::work", "10")
+                    .expect("should insert");
+            }
+            write_txn.commit().expect("should commit");
+        }
+
+        let summary = SummaryAssembler::assemble(&db, 10000).expect("should assemble");
+
+        // Should be sorted: identity (0.9), preferences (0.8), temporal (0.7), recent (0.6)
+        assert_eq!(summary.sections.len(), 4);
+        assert!(summary.sections[0].relevance_score >= summary.sections[1].relevance_score);
+        assert!(summary.sections[1].relevance_score >= summary.sections[2].relevance_score);
+        assert!(summary.sections[2].relevance_score >= summary.sections[3].relevance_score);
+    }
+}

--- a/crates/soul/src/temporal_model.rs
+++ b/crates/soul/src/temporal_model.rs
@@ -1,0 +1,178 @@
+//! Temporal user behavior model: hour-of-day and day-of-week patterns.
+
+use bus::events::soul::TemporalBehaviorPattern;
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+/// Temporal model that tracks event frequency by hour-of-day and day-of-week.
+pub(crate) struct TemporalModel {
+    /// Event counts bucketed by (hour, day_of_week, category).
+    buckets: HashMap<TemporalKey, u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TemporalKey {
+    hour_of_day: u8, // 0-23
+    day_of_week: u8, // 0=Monday, 6=Sunday
+    category: String,
+}
+
+impl TemporalModel {
+    pub(crate) fn new() -> Self {
+        Self {
+            buckets: HashMap::new(),
+        }
+    }
+
+    /// Record an event at the given timestamp with a category label.
+    pub(crate) fn record_event(&mut self, timestamp: SystemTime, category: &str) {
+        let (hour, day_of_week) = match extract_time_components(timestamp) {
+            Some(t) => t,
+            None => return, // Invalid timestamp, skip
+        };
+
+        let key = TemporalKey {
+            hour_of_day: hour,
+            day_of_week,
+            category: category.to_string(),
+        };
+
+        *self.buckets.entry(key).or_insert(0) += 1;
+    }
+
+    /// Get the top N temporal patterns sorted by frequency (descending).
+    pub(crate) fn top_patterns(&self, limit: usize) -> Vec<TemporalBehaviorPattern> {
+        let mut patterns: Vec<_> = self
+            .buckets
+            .iter()
+            .map(|(key, &frequency)| TemporalBehaviorPattern {
+                hour_of_day: Some(key.hour_of_day),
+                day_of_week: Some(key.day_of_week),
+                behavior_category: key.category.clone(),
+                frequency,
+            })
+            .collect();
+
+        patterns.sort_by(|a, b| b.frequency.cmp(&a.frequency));
+        patterns.truncate(limit);
+        patterns
+    }
+}
+
+/// Extract (hour_of_day, day_of_week) from SystemTime.
+/// Returns None if time is before UNIX_EPOCH or on error.
+fn extract_time_components(timestamp: SystemTime) -> Option<(u8, u8)> {
+    use std::time::UNIX_EPOCH;
+
+    let duration = timestamp.duration_since(UNIX_EPOCH).ok()?;
+    let secs = duration.as_secs();
+
+    // Convert to days and hours since epoch
+    let days_since_epoch = secs / 86400;
+    let seconds_in_day = secs % 86400;
+    let hour = (seconds_in_day / 3600) as u8;
+
+    // UNIX epoch (1970-01-01) was a Thursday (day 3 in our 0=Mon system)
+    // So: (days_since_epoch + 3) % 7 gives day_of_week where 0=Mon
+    let day_of_week = ((days_since_epoch + 3) % 7) as u8;
+
+    Some((hour, day_of_week))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    #[test]
+    fn temporal_model_records_events() {
+        let mut model = TemporalModel::new();
+        let timestamp = UNIX_EPOCH + Duration::from_secs(3600 * 15); // 15:00 on epoch day
+        model.record_event(timestamp, "inference");
+
+        let patterns = model.top_patterns(10);
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].behavior_category, "inference");
+        assert_eq!(patterns[0].frequency, 1);
+    }
+
+    #[test]
+    fn temporal_model_buckets_by_hour_and_day() {
+        let mut model = TemporalModel::new();
+
+        // Day 0 (Thursday, Jan 1 1970), hour 10
+        let t1 = UNIX_EPOCH + Duration::from_secs(3600 * 10);
+        model.record_event(t1, "work");
+
+        // Day 0, hour 10 again — should increment same bucket
+        let t2 = UNIX_EPOCH + Duration::from_secs(3600 * 10 + 1800);
+        model.record_event(t2, "work");
+
+        // Day 0, hour 15 — different bucket
+        let t3 = UNIX_EPOCH + Duration::from_secs(3600 * 15);
+        model.record_event(t3, "work");
+
+        let patterns = model.top_patterns(10);
+        assert_eq!(patterns.len(), 2);
+        assert_eq!(patterns[0].frequency, 2); // hour 10 bucket
+        assert_eq!(patterns[1].frequency, 1); // hour 15 bucket
+    }
+
+    #[test]
+    fn top_patterns_sorted_by_frequency() {
+        let mut model = TemporalModel::new();
+
+        let t1 = UNIX_EPOCH + Duration::from_secs(3600 * 9);
+        model.record_event(t1, "inference");
+        model.record_event(t1, "inference");
+        model.record_event(t1, "inference");
+
+        let t2 = UNIX_EPOCH + Duration::from_secs(3600 * 14);
+        model.record_event(t2, "inference");
+
+        let t3 = UNIX_EPOCH + Duration::from_secs(3600 * 22);
+        model.record_event(t3, "inference");
+        model.record_event(t3, "inference");
+
+        let patterns = model.top_patterns(3);
+        assert_eq!(patterns.len(), 3);
+        assert_eq!(patterns[0].frequency, 3); // hour 9
+        assert_eq!(patterns[1].frequency, 2); // hour 22
+        assert_eq!(patterns[2].frequency, 1); // hour 14
+    }
+
+    #[test]
+    fn top_patterns_respects_limit() {
+        let mut model = TemporalModel::new();
+
+        for hour in 0..10 {
+            let t = UNIX_EPOCH + Duration::from_secs(3600 * hour);
+            model.record_event(t, "activity");
+        }
+
+        let patterns = model.top_patterns(3);
+        assert_eq!(patterns.len(), 3);
+    }
+
+    #[test]
+    fn extract_time_components_handles_epoch() {
+        let (hour, day) = extract_time_components(UNIX_EPOCH).expect("should parse epoch");
+        assert_eq!(hour, 0);
+        assert_eq!(day, 3); // Thursday = 3 in 0=Monday system
+    }
+
+    #[test]
+    fn extract_time_components_handles_various_times() {
+        // 1 day + 12 hours = Friday 12:00
+        let t = UNIX_EPOCH + Duration::from_secs(86400 + 3600 * 12);
+        let (hour, day) = extract_time_components(t).expect("should parse");
+        assert_eq!(hour, 12);
+        assert_eq!(day, 4); // Friday = 4 in 0=Monday system
+
+        // 3 days = Sunday 00:00
+        let t = UNIX_EPOCH + Duration::from_secs(86400 * 3);
+        let (hour, day) = extract_time_components(t).expect("should parse");
+        assert_eq!(hour, 0);
+        assert_eq!(day, 6); // Sunday = 6 in 0=Monday system
+    }
+}


### PR DESCRIPTION
## Phase 7A — Soul Intelligence Layer

Closes #25

Elevates Soul from flat storage to active intelligence:
- Identity distillation: harvests DistilledIdentitySignal from observation counters
- Temporal behavior model: hour x day_of_week bucketed activity patterns
- Preference learning: engagement signals -> verbosity, engagement, proactiveness
- Rich summary assembler: multi-section RichSoulSummary with token budget
- Soul actor: periodic intelligence harvesting every 50 events

**Depends on:** feat/bus-intelligence-events
**Arch-guard:** APPROVED
**Sec-auditor:** CLEAN
**Reviewer:** APPROVED
**Tests:** 45 Soul tests + 4 integration tests