### PR TITLE
runtime: wire orphaned event subscriptions and export stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,29 +331,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -367,7 +344,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
 ]
@@ -981,7 +958,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -1282,6 +1259,16 @@ name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -2376,13 +2363,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac-sha256"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hora"
@@ -2777,15 +2761,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2944,12 +2919,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leb128fmt"
@@ -3116,7 +3085,7 @@ version = "0.1.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f2cf3435dbadb87817e0a95325c818cd89d43026e8ba1ddd32f1d980d96f33d"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "cmake",
  "find_cuda_helper",
@@ -3153,6 +3122,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 
 [[package]]
 name = "mac_address"
@@ -3205,6 +3180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
 ]
 
 [[package]]
@@ -3333,6 +3318,38 @@ dependencies = [
  "png 0.17.16",
  "thiserror 1.0.69",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
 ]
 
 [[package]]
@@ -3715,6 +3732,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3737,6 +3798,30 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq 3.3.0",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq 3.3.0",
 ]
 
 [[package]]
@@ -3771,6 +3856,22 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "parakeet-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2c29bb70e3b63ddfa9af7cbb66f87a200550a5f6a5ac82fabf527b270c6615"
+dependencies = [
+ "eyre",
+ "hound",
+ "ndarray",
+ "ort",
+ "realfft",
+ "serde",
+ "serde_json",
+ "tokenizers 0.22.2",
 ]
 
 [[package]]
@@ -3818,6 +3919,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4027,6 +4137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4058,6 +4177,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -4176,7 +4304,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4196,7 +4324,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4405,6 +4533,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4449,6 +4583,15 @@ dependencies = [
  "libc",
  "winapi",
  "x11",
+]
+
+[[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
 ]
 
 [[package]]
@@ -4641,12 +4784,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -4658,6 +4795,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -4752,6 +4903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4952,35 +5112,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "sherpa-rs"
-version = "0.6.8"
+name = "sherpa-onnx"
+version = "1.12.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81835d89a3fc44482a6829e3e2483ac83f7b4d1623c76f196c77c9ecf5c18203"
+checksum = "f69ec9bc7c245dc7b976e7662c8529b32236efb04ab9d53427af2c4b8393b0da"
 dependencies = [
- "eyre",
- "hound",
- "sherpa-rs-sys",
- "tracing",
+ "serde",
+ "serde_json",
+ "sherpa-onnx-sys",
 ]
 
 [[package]]
-name = "sherpa-rs-sys"
-version = "0.6.8"
+name = "sherpa-onnx-sys"
+version = "1.12.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591c9432b20f41d47f622a73c2888b188c321e313d820824df7d9fa51dbada43"
+checksum = "b78e254a3030040d015edcdc4adfa1ea4714d3284dba0034f120feccbbde4aff"
 dependencies = [
- "bindgen 0.69.5",
  "bzip2",
- "cmake",
- "dirs",
- "flate2",
- "glob",
- "lazy_static",
- "serde",
- "serde_json",
- "sha2",
  "tar",
- "ureq",
+ "ureq 2.12.1",
 ]
 
 [[package]]
@@ -5092,11 +5242,13 @@ dependencies = [
  "cpal",
  "futures-util",
  "hex",
+ "parakeet-rs",
  "rand 0.9.2",
  "reqwest",
+ "serde",
  "serde_json",
  "sha2",
- "sherpa-rs",
+ "sherpa-onnx",
  "tempfile",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
@@ -5122,7 +5274,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c3e8acdf2b1f4bb13f1813b40b52f3edf4cc94d8a55fe713a584f672a10388d"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -5148,6 +5300,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -5815,6 +5973,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5973,13 +6141,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
+ "flate2",
  "log",
  "once_cell",
  "rustls",
  "rustls-pki-types",
- "socks",
  "url",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -5993,6 +6191,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6024,6 +6228,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -6212,6 +6422,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6305,18 +6524,6 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -331,6 +331,29 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
+ "which",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -344,7 +367,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -497,6 +520,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -938,7 +981,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
 ]
 
 [[package]]
@@ -1544,6 +1587,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -1618,6 +1671,17 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -2264,6 +2328,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hora"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2319,6 +2398,12 @@ dependencies = [
  "rayon",
  "serde",
 ]
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
@@ -2393,7 +2478,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2573,13 +2658,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.13.0"
+name = "indenter"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2686,6 +2777,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2764,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2846,6 +2946,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,9 +2983,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libdbus-sys"
@@ -2922,7 +3028,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -2989,9 +3098,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.141"
+version = "0.1.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e168663718200aaa86617d352a264ce0226bc7727139e9601e9aae926a06fb1"
+checksum = "d564eb5d7ae88f596e7636ffd549e0f27f4c938a7c7841bb91e2a92c248c9ccb"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -3003,11 +3112,11 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.141"
+version = "0.1.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec26e2c8669ac39957505d725f1e06afc79f6f813b67b2b52c2736d65309dc1e"
+checksum = "2f2cf3435dbadb87817e0a95325c818cd89d43026e8ba1ddd32f1d980d96f33d"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "cc",
  "cmake",
  "find_cuda_helper",
@@ -3688,7 +3797,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -3835,6 +3944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "platform"
 version = "0.1.0"
 dependencies = [
@@ -3971,7 +4086,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -4012,10 +4127,6 @@ name = "prompt"
 version = "0.1.0"
 dependencies = [
  "bus",
- "ctp",
- "inference",
- "memory",
- "text",
  "thiserror 2.0.18",
 ]
 
@@ -4065,7 +4176,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -4085,7 +4196,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4357,9 +4468,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b440f171acaaddcd7e65eefc2ce4f4d4e05c1dffe2afe23f81af2a87cbfc4e0d"
+checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
 dependencies = [
  "libc",
 ]
@@ -4369,6 +4480,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -4451,7 +4571,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4521,6 +4641,12 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
@@ -4566,6 +4692,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4690,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -4825,6 +4952,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "sherpa-rs"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81835d89a3fc44482a6829e3e2483ac83f7b4d1623c76f196c77c9ecf5c18203"
+dependencies = [
+ "eyre",
+ "hound",
+ "sherpa-rs-sys",
+ "tracing",
+]
+
+[[package]]
+name = "sherpa-rs-sys"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591c9432b20f41d47f622a73c2888b188c321e313d820824df7d9fa51dbada43"
+dependencies = [
+ "bindgen 0.69.5",
+ "bzip2",
+ "cmake",
+ "dirs",
+ "flate2",
+ "glob",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "ureq",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4896,13 +5055,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "soul"
 version = "0.1.0"
 dependencies = [
  "async-trait",
  "bus",
  "crypto",
- "redb 3.1.2",
+ "redb 3.1.3",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4926,6 +5096,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "sha2",
+ "sherpa-rs",
  "tempfile",
  "thiserror 2.0.18",
  "tokenizers 0.21.4",
@@ -4951,7 +5122,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c3e8acdf2b1f4bb13f1813b40b52f3edf4cc94d8a55fe713a584f672a10388d"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
 ]
 
 [[package]]
@@ -5092,6 +5263,17 @@ dependencies = [
  "pkg-config",
  "toml 0.8.2",
  "version-compare",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5369,9 +5551,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -5386,9 +5568,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5489,9 +5671,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5785,6 +5967,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5893,9 +6091,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5906,9 +6104,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5916,9 +6114,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5926,9 +6124,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5939,9 +6137,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5995,9 +6193,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6011,6 +6209,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6098,6 +6305,18 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -6732,9 +6951,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x11"
@@ -6762,6 +6981,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "xdg-home"

--- a/crates/bus/src/events/speech.rs
+++ b/crates/bus/src/events/speech.rs
@@ -126,6 +126,40 @@ pub enum SpeechEvent {
         /// Session ID that was stopped.
         session_id: u64,
     },
+
+    /// User or system requests STT backend change.
+    SttBackendSwitchRequested {
+        /// Target backend: "whisper", "sherpa", "parakeet"
+        backend: String,
+    },
+
+    /// STT actor confirms backend switch completed.
+    SttBackendSwitchCompleted {
+        /// Backend that is now active.
+        backend: String,
+    },
+
+    /// STT actor reports backend switch failed.
+    SttBackendSwitchFailed {
+        /// Backend that was requested.
+        backend: String,
+        /// Failure reason.
+        reason: String,
+    },
+
+    /// STT actor emits telemetry after each transcription.
+    SttTelemetryUpdate {
+        /// Backend used for this transcription.
+        backend: String,
+        /// VRAM usage in MB (None if not measurable).
+        vram_mb: Option<f64>,
+        /// Time from audio end to text ready in milliseconds.
+        latency_ms: f64,
+        /// Average word confidence [0.0, 1.0].
+        avg_confidence: f64,
+        /// Request ID for correlation.
+        request_id: u64,
+    },
 }
 
 #[cfg(test)]
@@ -220,6 +254,75 @@ mod tests {
             assert_eq!(recoverable, true);
         } else {
             panic!("Expected SpeechOnboardingFailed variant");
+        }
+    }
+
+    #[test]
+    fn stt_backend_switch_requested_constructs_and_clones() {
+        let event = SpeechEvent::SttBackendSwitchRequested {
+            backend: "sherpa".to_string(),
+        };
+        let cloned = event.clone();
+        if let SpeechEvent::SttBackendSwitchRequested { backend } = cloned {
+            assert_eq!(backend, "sherpa");
+        } else {
+            panic!("Expected SttBackendSwitchRequested variant");
+        }
+    }
+
+    #[test]
+    fn stt_backend_switch_completed_constructs_and_clones() {
+        let event = SpeechEvent::SttBackendSwitchCompleted {
+            backend: "whisper".to_string(),
+        };
+        let cloned = event.clone();
+        if let SpeechEvent::SttBackendSwitchCompleted { backend } = cloned {
+            assert_eq!(backend, "whisper");
+        } else {
+            panic!("Expected SttBackendSwitchCompleted variant");
+        }
+    }
+
+    #[test]
+    fn stt_backend_switch_failed_constructs_and_clones() {
+        let event = SpeechEvent::SttBackendSwitchFailed {
+            backend: "parakeet".to_string(),
+            reason: "model not found".to_string(),
+        };
+        let cloned = event.clone();
+        if let SpeechEvent::SttBackendSwitchFailed { backend, reason } = cloned {
+            assert_eq!(backend, "parakeet");
+            assert_eq!(reason, "model not found");
+        } else {
+            panic!("Expected SttBackendSwitchFailed variant");
+        }
+    }
+
+    #[test]
+    fn stt_telemetry_update_constructs_and_clones() {
+        let event = SpeechEvent::SttTelemetryUpdate {
+            backend: "whisper".to_string(),
+            vram_mb: Some(256.0),
+            latency_ms: 120.5,
+            avg_confidence: 0.92,
+            request_id: 42,
+        };
+        let cloned = event.clone();
+        if let SpeechEvent::SttTelemetryUpdate {
+            backend,
+            vram_mb,
+            latency_ms,
+            avg_confidence,
+            request_id,
+        } = cloned
+        {
+            assert_eq!(backend, "whisper");
+            assert_eq!(vram_mb, Some(256.0));
+            assert_eq!(latency_ms, 120.5);
+            assert_eq!(avg_confidence, 0.92);
+            assert_eq!(request_id, 42);
+        } else {
+            panic!("Expected SttTelemetryUpdate variant");
         }
     }
 

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -172,6 +172,11 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         category: CommandCategory::System,
     },
     SlashCommand {
+        command: "/export",
+        description: "Request Soul export (/export [path])",
+        category: CommandCategory::System,
+    },
+    SlashCommand {
         command: "/help",
         description: "Show all commands",
         category: CommandCategory::System,
@@ -303,6 +308,9 @@ struct Shell {
     voice_enabled: bool,
     /// Last emitted download-progress bucket (0..=10) keyed by request ID.
     download_progress: HashMap<u64, u64>,
+    /// Maps session_id → message index for pending LLM transcript refinements.
+    /// Cleared when TranscriptRefined arrives or when the entry count exceeds the cap.
+    pending_refinements: HashMap<u64, usize>,
 }
 
 impl Shell {
@@ -329,6 +337,7 @@ impl Shell {
             runtime,
             voice_enabled,
             download_progress: HashMap::new(),
+            pending_refinements: HashMap::new(),
         }
     }
 
@@ -1253,6 +1262,7 @@ impl Shell {
             Event::Speech(SpeechEvent::ListenModeTranscription {
                 text,
                 is_final,
+                is_new_sentence,
                 confidence,
                 session_id,
             }) if session_id == self.state.listen_session_id => {
@@ -1262,15 +1272,41 @@ impl Shell {
                         format!("[listen ~{:.0}%] {}", confidence * 100.0, text),
                     );
                 } else if is_final {
-                    // Committed utterance: replace any in-flight interim line with the final.
+                    // VAD flush commit: turn gray row green.
                     if let Some(last) = self.state.messages.last() {
                         if last.role == MessageRole::System && last.text.starts_with("[\u{2026}] ") {
                             self.state.messages.pop();
                         }
                     }
                     self.add_message(MessageRole::Sena, text);
+                    // Record the message index for LLM refinement replacement.
+                    let msg_idx = self.state.messages.len() - 1;
+                    // Cap to prevent unbounded growth when model is never loaded.
+                    const MAX_PENDING_REFINEMENTS: usize = 20;
+                    if self.pending_refinements.len() >= MAX_PENDING_REFINEMENTS {
+                        if let Some(&oldest) = self.pending_refinements.keys().min() {
+                            self.pending_refinements.remove(&oldest);
+                        }
+                    }
+                    self.pending_refinements.insert(session_id, msg_idx);
+                } else if is_new_sentence {
+                    // Long inactivity gap: commit the in-progress gray row as green,
+                    // then start a new gray row with the first token of the new sentence.
+                    let prefix = "[\u{2026}] ";
+                    if let Some(last) = self.state.messages.last() {
+                        if last.role == MessageRole::System && last.text.starts_with(prefix) {
+                            let committed = last.text[prefix.len()..].to_string();
+                            let idx = self.state.messages.len() - 1;
+                            self.state.messages[idx].role = MessageRole::Sena;
+                            self.state.messages[idx].text = committed;
+                        }
+                    }
+                    // Start a fresh gray streaming row for the new sentence.
+                    self.state
+                        .messages
+                        .push(Message::new(MessageRole::System, format!("{}{}", prefix, text)));
                 } else {
-                    // Streaming interim update — replace in-place, do not flood the log.
+                    // Streaming partial — replace in-place.
                     self.update_or_add_streaming(text);
                 }
             }
@@ -1282,6 +1318,18 @@ impl Shell {
                         MessageRole::System,
                         format!("[verbose] Loop {}: {}", loop_name, status),
                     );
+                }
+            }
+            Event::Speech(SpeechEvent::TranscriptRefined {
+                cleaned_text,
+                session_id,
+            }) => {
+                if let Some(idx) = self.pending_refinements.remove(&session_id) {
+                    if let Some(msg) = self.state.messages.get_mut(idx) {
+                        if msg.role == MessageRole::Sena {
+                            msg.text = cleaned_text;
+                        }
+                    }
                 }
             }
             Event::Speech(SpeechEvent::ListenModeStopped { session_id })
@@ -1596,6 +1644,7 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
         return Ok(DispatchResult::Continue);
     }
 
+    let parts: Vec<&str> = line.split_whitespace().collect();
     let lower = line.to_lowercase();
     let cmd = lower.split_whitespace().next().unwrap_or("");
     match cmd {
@@ -1807,6 +1856,26 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
             show_status_shared(deps.runtime, deps.state).await;
             Ok(DispatchResult::Continue)
         }
+        "/export" => {
+            let path = parts
+                .get(1)
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("sena-soul-export.json"));
+            transport
+                .send(
+                    target,
+                    Event::Soul(bus::events::soul::SoulEvent::ExportRequested {
+                        path: path.clone(),
+                    }),
+                )
+                .await?;
+            add_message(
+                deps.state,
+                MessageRole::System,
+                &format!("Requested Soul export to {}", path.display()),
+            );
+            Ok(DispatchResult::Continue)
+        }
         "/help" | "/h" => {
             show_help_shared(deps.state);
             Ok(DispatchResult::Continue)
@@ -1897,6 +1966,11 @@ fn event_to_ipc_payload(event: &Event) -> Result<IpcPayload> {
         Event::Speech(SpeechEvent::SttBackendSwitchRequested { backend }) => {
             Ok(IpcPayload::SlashCommand {
                 line: format!("/stt-backend {}", backend),
+            })
+        }
+        Event::Soul(bus::events::soul::SoulEvent::ExportRequested { path }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!("/export {}", path.display()),
             })
         }
         Event::System(bus::events::SystemEvent::ShutdownSignal) => {

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -906,6 +906,23 @@ impl Shell {
         }
     }
 
+    /// Update the last streaming interim message in-place or add a new one.
+    ///
+    /// Used for streaming transcription so interim `[…] text` updates replace each
+    /// other rather than flooding the conversation log with duplicate lines.
+    fn update_or_add_streaming(&mut self, text: String) {
+        let prefix = "[\u{2026}] ";
+        let full = format!("{}{}", prefix, text);
+        // Replace the last message if it is already a streaming interim line.
+        if let Some(last) = self.state.messages.last_mut() {
+            if last.role == MessageRole::System && last.text.starts_with(prefix) {
+                last.text = full;
+                return;
+            }
+        }
+        self.state.messages.push(Message::new(MessageRole::System, full));
+    }
+
     /// Handle bus events and update internal state.
     async fn handle_bus_event(&mut self, event: Event) {
         match event {
@@ -1245,9 +1262,16 @@ impl Shell {
                         format!("[listen ~{:.0}%] {}", confidence * 100.0, text),
                     );
                 } else if is_final {
+                    // Committed utterance: replace any in-flight interim line with the final.
+                    if let Some(last) = self.state.messages.last() {
+                        if last.role == MessageRole::System && last.text.starts_with("[\u{2026}] ") {
+                            self.state.messages.pop();
+                        }
+                    }
                     self.add_message(MessageRole::Sena, text);
                 } else {
-                    self.add_message(MessageRole::System, format!("[\u{2026}] {}", text));
+                    // Streaming interim update — replace in-place, do not flood the log.
+                    self.update_or_add_streaming(text);
                 }
             }
             Event::System(bus::events::SystemEvent::LoopStatusChanged { loop_name, enabled }) => {

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -1112,7 +1112,7 @@ impl Shell {
                         text,
                         request_id,
                         Priority::Normal,
-                        Some("[voice] "),
+                        Some("[you]: "),
                     )
                     .await;
                 }
@@ -1654,6 +1654,17 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
             } else {
                 "OFF"
             };
+            // Broadcast speech loop control to the daemon.
+            transport
+                .send(
+                    target,
+                    Event::System(bus::events::SystemEvent::LoopControlRequested {
+                        loop_name: "speech".to_string(),
+                        enabled: deps.command_state.voice_enabled,
+                    }),
+                )
+                .await
+                .ok();
             add_message(
                 deps.state,
                 MessageRole::System,

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -150,6 +150,11 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         description: "List microphones or select one (/microphone select <index>)",
         category: CommandCategory::Audio,
     },
+    SlashCommand {
+        command: "/stt-backend",
+        description: "Switch STT backend (/stt-backend <whisper|sherpa|parakeet>)",
+        category: CommandCategory::Audio,
+    },
     // System category
     SlashCommand {
         command: "/screenshot",
@@ -1264,6 +1269,18 @@ impl Shell {
                     "\u{1f3a4} Listen mode stopped.".to_string(),
                 );
             }
+            Event::Speech(SpeechEvent::SttBackendSwitchCompleted { backend }) => {
+                self.add_message(
+                    MessageRole::System,
+                    format!("✓ STT backend switched to: {}", backend),
+                );
+            }
+            Event::Speech(SpeechEvent::SttBackendSwitchFailed { backend, reason }) => {
+                self.add_message(
+                    MessageRole::Warning,
+                    format!("Failed to switch to {}: {}", backend, reason),
+                );
+            }
             other if self.verbose => {
                 if let Some(msg) = verbose_format(&other) {
                     self.add_message(MessageRole::System, msg);
@@ -1730,6 +1747,10 @@ async fn dispatch_command<T: MessageTransport + ?Sized>(
         }
         "/microphone" => {
             handle_microphone_command(line, transport, target, deps.state).await?;
+            Ok(DispatchResult::Continue)
+        }
+        "/stt-backend" => {
+            handle_stt_backend_command(line, transport, target, deps.state).await?;
             Ok(DispatchResult::Continue)
         }
         "/screenshot" => {
@@ -2226,6 +2247,82 @@ async fn handle_loops_command<T: MessageTransport + ?Sized>(
     Ok(())
 }
 
+async fn handle_stt_backend_command<T: MessageTransport + ?Sized>(
+    line: &str,
+    transport: &mut T,
+    target: &mut DispatchTarget<'_>,
+    state: &mut crate::tui_state::ShellState<SlashDropdown>,
+) -> Result<()> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+
+    match parts.as_slice() {
+        ["/stt-backend"] => {
+            // Show current backend + valid options
+            let config = runtime::config::load_or_create_config().await?;
+            add_message(state, MessageRole::System, "━━  STT Backend");
+            add_message(
+                state,
+                MessageRole::System,
+                &format!("Current: {:?}", config.stt_backend),
+            );
+            add_message(
+                state,
+                MessageRole::System,
+                "Available: whisper, sherpa, parakeet",
+            );
+            add_message(state, MessageRole::System, "Usage: /stt-backend <backend>");
+        }
+        ["/stt-backend", backend_str] => {
+            // Prevent switch during active listen
+            if state.listen_mode_active {
+                add_message(
+                    state,
+                    MessageRole::Warning,
+                    "Cannot switch STT backend during /listen. Stop listening first.",
+                );
+                return Ok(());
+            }
+
+            // Validate backend name
+            let backend = match backend_str.to_lowercase().as_str() {
+                "whisper" | "sherpa" | "parakeet" => backend_str.to_lowercase(),
+                _ => {
+                    add_message(
+                        state,
+                        MessageRole::Warning,
+                        "Invalid backend. Use: whisper, sherpa, parakeet",
+                    );
+                    return Ok(());
+                }
+            };
+
+            // Broadcast switch request
+            transport
+                .send(
+                    target,
+                    Event::Speech(SpeechEvent::SttBackendSwitchRequested {
+                        backend: backend.clone(),
+                    }),
+                )
+                .await?;
+
+            add_message(
+                state,
+                MessageRole::System,
+                &format!("Switching STT backend to {}...", backend),
+            );
+        }
+        _ => {
+            add_message(
+                state,
+                MessageRole::Warning,
+                "Usage: /stt-backend | /stt-backend <whisper|sherpa|parakeet>",
+            );
+        }
+    }
+    Ok(())
+}
+
 fn show_help_shared(state: &mut crate::tui_state::ShellState<SlashDropdown>) {
     add_message(state, MessageRole::System, "━━  Commands");
 
@@ -2342,7 +2439,11 @@ async fn show_status_shared(
         add_message(
             state,
             MessageRole::System,
-            &format!("  {}: {}", name, if enabled { "enabled" } else { "disabled" }),
+            &format!(
+                "  {}: {}",
+                name,
+                if enabled { "enabled" } else { "disabled" }
+            ),
         );
     }
 
@@ -2354,10 +2455,22 @@ async fn show_status_shared(
             .map(|c| c.speech_enabled)
             .unwrap_or(false)
     };
-    let speech_status = if speech_enabled { "enabled" } else { "disabled" };
+    let speech_status = if speech_enabled {
+        "enabled"
+    } else {
+        "disabled"
+    };
     add_message(state, MessageRole::System, "Speech");
-    add_message(state, MessageRole::System, &format!("  STT: {}", speech_status));
-    add_message(state, MessageRole::System, &format!("  TTS: {}", speech_status));
+    add_message(
+        state,
+        MessageRole::System,
+        &format!("  STT: {}", speech_status),
+    );
+    add_message(
+        state,
+        MessageRole::System,
+        &format!("  TTS: {}", speech_status),
+    );
 }
 
 fn copy_last_response_shared(state: &mut crate::tui_state::ShellState<SlashDropdown>) {

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -1870,6 +1870,11 @@ fn event_to_ipc_payload(event: &Event) -> Result<IpcPayload> {
                 ),
             })
         }
+        Event::Speech(SpeechEvent::SttBackendSwitchRequested { backend }) => {
+            Ok(IpcPayload::SlashCommand {
+                line: format!("/stt-backend {}", backend),
+            })
+        }
         Event::System(bus::events::SystemEvent::ShutdownSignal) => {
             Ok(IpcPayload::ShutdownRequested)
         }

--- a/crates/crypto/src/working_file.rs
+++ b/crates/crypto/src/working_file.rs
@@ -95,8 +95,7 @@ mod tests {
         let original = b"hello encrypted working file";
 
         // Write encrypted file via existing primitive
-        crate::file::write_encrypted_file(&enc_path, original, &test_master_key())
-            .expect("write");
+        crate::file::write_encrypted_file(&enc_path, original, &test_master_key()).expect("write");
 
         // Decrypt to working
         let existed = decrypt_to_working(&enc_path, &work_path, &test_master_key())

--- a/crates/inference/src/actor.rs
+++ b/crates/inference/src/actor.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use bus::events::ctp::{CTPEvent, ContextSnapshot};
 use bus::events::inference::Priority;
 use bus::events::memory::{MemoryChunk, MemoryQueryRequest, MemoryWriteRequest};
-use bus::events::soul::{IdentitySignalEmitted, SoulSummary, SoulSummaryRequested};
+use bus::events::soul::{IdentitySignalEmitted, RichSoulSummary, SoulSummary};
 use bus::events::transparency::{TransparencyEvent, TransparencyQuery};
 use bus::events::InferenceEvent;
 use bus::{Actor, ActorError, Event, EventBus, MemoryEvent, SoulEvent, SpeechEvent, SystemEvent};
@@ -97,6 +97,8 @@ pub struct InferenceActor {
     embed_model_path: Option<PathBuf>,
     /// Dedicated embedding backend (lazy-initialized on first WorkKind::Embed use).
     embed_backend: Option<Arc<Mutex<Box<dyn LlmBackend>>>>,
+    /// Cached RichSoulSummary from the most recent SoulEvent::RichSummaryReady broadcast.
+    latest_rich_summary: Option<RichSoulSummary>,
 }
 
 impl InferenceActor {
@@ -136,6 +138,7 @@ impl InferenceActor {
             streaming_max_sentence_chars: 400,
             embed_model_path: None,
             embed_backend: None,
+            latest_rich_summary: None,
         }
     }
 
@@ -876,6 +879,20 @@ impl InferenceActor {
         parts.join("\n\n")
     }
 
+    fn rich_summary_to_legacy(summary: &RichSoulSummary) -> SoulSummary {
+        let content = summary
+            .sections
+            .iter()
+            .map(|s| s.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n---\n");
+        SoulSummary {
+            content,
+            event_count: summary.sections.len(),
+            request_id: summary.request_id,
+        }
+    }
+
     fn active_hours_range_utc(now: SystemTime) -> String {
         let hour = now
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -945,7 +962,12 @@ impl InferenceActor {
         let soul_summary = self
             .query_soul_with_timeout(bus, soul_request_id, SINGLE_ROUND_MEMORY_TIMEOUT)
             .await
-            .ok();
+            .ok()
+            .or_else(|| {
+                self.latest_rich_summary
+                    .as_ref()
+                    .map(Self::rich_summary_to_legacy)
+            });
 
         // Acquire vision frame if model is vision-capable
         let vision_base64: Option<String> = self
@@ -1101,7 +1123,12 @@ impl InferenceActor {
         let soul_summary = self
             .query_soul_with_timeout(bus, soul_request_id, SINGLE_ROUND_MEMORY_TIMEOUT)
             .await
-            .ok();
+            .ok()
+            .or_else(|| {
+                self.latest_rich_summary
+                    .as_ref()
+                    .map(Self::rich_summary_to_legacy)
+            });
 
         // Acquire vision frame if model is vision-capable
         let vision_base64: Option<String> = self
@@ -1382,14 +1409,12 @@ impl InferenceActor {
     ) -> Result<SoulSummary, String> {
         let mut rx = bus.subscribe_broadcast();
 
-        // TODO Phase 7B: switch to RichSummaryRequested for section-based prompt assembly
         bus.send_directed(
             "soul",
-            Event::Soul(SoulEvent::SummaryRequested(SoulSummaryRequested {
-                max_events: 20,
+            Event::Soul(SoulEvent::RichSummaryRequested {
+                token_budget: 2048,
                 request_id,
-                max_chars: None,
-            })),
+            }),
         )
         .await
         .map_err(|e| format!("soul summary dispatch failed: {}", e))?;
@@ -1404,10 +1429,12 @@ impl InferenceActor {
             tokio::select! {
                 event = rx.recv() => {
                     match event {
-                        Ok(Event::Soul(SoulEvent::SummaryReady(summary)))
+                        Ok(Event::Soul(SoulEvent::RichSummaryReady(summary)))
                             if summary.request_id == request_id =>
                         {
-                            return Ok(summary);
+                            // Convert RichSoulSummary sections to flat SoulSummary for
+                            // backward compat with build_enriched_prompt.
+                            return Ok(Self::rich_summary_to_legacy(&summary));
                         }
                         Ok(_) => continue,
                         Err(_) => return Err("bus closed".to_string()),
@@ -1843,6 +1870,78 @@ impl Actor for InferenceActor {
                                 }
                             }
                         }
+                        Ok(Event::Speech(SpeechEvent::ListenModeTranscription {
+                            is_final,
+                            text,
+                            session_id,
+                            ..
+                        })) if is_final => {
+                            // Transcript cleanup: LLM-based correction of STT acoustic errors.
+                            // Only process final transcripts when model is ready.
+                            let model_is_ready = self
+                                .backend
+                                .lock()
+                                .map(|g| g.is_loaded())
+                                .unwrap_or(false);
+                            if !model_is_ready {
+                                continue;
+                            }
+
+                            let trimmed = text.trim();
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+
+                        let cleanup_prompt = text::transcript_cleanup_prompt(&text);
+
+                        let template = self
+                            .current_model_name
+                            .as_ref()
+                            .map(|name| ChatTemplate::detect_from_model_name(name))
+                            .unwrap_or(ChatTemplate::Raw);
+                        let wrapped = template.wrap(&cleanup_prompt);
+
+                        let max_tokens = (text.split_whitespace().count() * 2).clamp(64, 256);
+
+                        let (adjusted_max_tokens, _) = match Self::calculate_adjusted_max_tokens(
+                            &wrapped,
+                            max_tokens,
+                            self.inference_ctx_size as usize,
+                        ) {
+                                Ok(r) => r,
+                                Err(e) => {
+                                    tracing::warn!("transcript cleanup: prompt too large: {}", e);
+                                    continue;
+                                }
+                            };
+
+                            let params = InferenceParams {
+                                request_id: uuid::Uuid::new_v4(),
+                                prompt: wrapped,
+                                temperature: 0.1,
+                                top_p: 0.9,
+                                max_tokens: adjusted_max_tokens,
+                                ctx_size: self.inference_ctx_size,
+                            };
+
+                            let backend_clone = self.backend.clone();
+                            match Self::complete_with_overflow_retry(backend_clone, params).await {
+                                Ok(cleaned) => {
+                                    let cleaned = cleaned.trim().to_string();
+                                    if !cleaned.is_empty() {
+                                        let _ = bus
+                                            .broadcast(Event::Speech(SpeechEvent::TranscriptRefined {
+                                                cleaned_text: cleaned,
+                                                session_id,
+                                            }))
+                                            .await;
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!("transcript cleanup failed for session {}: {}", session_id, e);
+                                }
+                            }
+                        }
                         Ok(Event::Transparency(TransparencyEvent::QueryRequested(
                             TransparencyQuery::InferenceExplanation,
                         ))) => {
@@ -1880,6 +1979,20 @@ impl Actor for InferenceActor {
                                     ))
                                     .await;
                             });
+                        }
+                        Ok(Event::Soul(SoulEvent::RichSummaryReady(summary))) => {
+                            tracing::debug!(
+                                "inference: cached RichSoulSummary {} sections request_id={}",
+                                summary.sections.len(),
+                                summary.request_id
+                            );
+                            self.latest_rich_summary = Some(summary);
+                        }
+                        Ok(Event::Memory(MemoryEvent::WriteCompleted(ref wc))) => {
+                            tracing::debug!(
+                                "inference: memory confirmed write request_id={}",
+                                wc.request_id
+                            );
                         }
                         Err(broadcast::error::RecvError::Closed) => {
                             return Err(ActorError::ChannelClosed("bus channel closed".to_string()));

--- a/crates/inference/src/identity_signals.rs
+++ b/crates/inference/src/identity_signals.rs
@@ -23,65 +23,149 @@ pub fn extract_identity_signals(response: &str) -> Vec<(String, String)> {
     let lower = response.to_lowercase();
 
     // Work domain patterns
-    if contains_any(&lower, &[
-        "code", "coding", "programming", "software", "development", "developer",
-        "function", "class", "variable", "algorithm", "debug", "compile",
-        "git", "version control", "repository", "commit", "branch",
-        "rust", "python", "javascript", "typescript", "api", "fastapi",
-    ]) {
-        signals.push(("work_domain".to_string(), "software_development".to_string()));
+    if contains_any(
+        &lower,
+        &[
+            "code",
+            "coding",
+            "programming",
+            "software",
+            "development",
+            "developer",
+            "function",
+            "class",
+            "variable",
+            "algorithm",
+            "debug",
+            "compile",
+            "git",
+            "version control",
+            "repository",
+            "commit",
+            "branch",
+            "rust",
+            "python",
+            "javascript",
+            "typescript",
+            "api",
+            "fastapi",
+        ],
+    ) {
+        signals.push((
+            "work_domain".to_string(),
+            "software_development".to_string(),
+        ));
     }
 
     // Rust programming preference
-    if contains_any(&lower, &[
-        "rust", "cargo", "rustc", "tokio", "async", "trait", "borrow checker",
-    ]) {
+    if contains_any(
+        &lower,
+        &[
+            "rust",
+            "cargo",
+            "rustc",
+            "tokio",
+            "async",
+            "trait",
+            "borrow checker",
+        ],
+    ) {
         signals.push(("tool_preference".to_string(), "rust".to_string()));
     }
 
     // Python programming preference
-    if contains_any(&lower, &[
-        "python", "pip", "numpy", "pandas", "django", "pytorch",
-    ]) {
+    if contains_any(
+        &lower,
+        &["python", "pip", "numpy", "pandas", "django", "pytorch"],
+    ) {
         signals.push(("tool_preference".to_string(), "python".to_string()));
     }
 
     // JavaScript/TypeScript preference
-    if contains_any(&lower, &[
-        "javascript", "typescript", "node", "npm", "react", "vue", "angular",
-    ]) {
+    if contains_any(
+        &lower,
+        &[
+            "javascript",
+            "typescript",
+            "node",
+            "npm",
+            "react",
+            "vue",
+            "angular",
+        ],
+    ) {
         signals.push(("tool_preference".to_string(), "javascript".to_string()));
     }
 
     // AI/ML interest cluster
-    if contains_any(&lower, &[
-        "machine learning", "neural network", "deep learning", "model training",
-        "inference", "transformer", "embeddings", "llm", "language model",
-    ]) {
-        signals.push(("interest".to_string(), "artificial_intelligence".to_string()));
+    if contains_any(
+        &lower,
+        &[
+            "machine learning",
+            "neural network",
+            "deep learning",
+            "model training",
+            "inference",
+            "transformer",
+            "embeddings",
+            "llm",
+            "language model",
+        ],
+    ) {
+        signals.push((
+            "interest".to_string(),
+            "artificial_intelligence".to_string(),
+        ));
     }
 
     // Systems programming interest
-    if contains_any(&lower, &[
-        "memory management", "concurrency", "threading", "async runtime",
-        "low-level", "performance optimization", "systems programming",
-    ]) {
+    if contains_any(
+        &lower,
+        &[
+            "memory management",
+            "concurrency",
+            "threading",
+            "async runtime",
+            "low-level",
+            "performance optimization",
+            "systems programming",
+        ],
+    ) {
         signals.push(("interest".to_string(), "systems_programming".to_string()));
     }
 
     // Web development interest
-    if contains_any(&lower, &[
-        "web development", "frontend", "backend", "api", "rest", "graphql",
-        "http", "server", "client", "browser",
-    ]) {
+    if contains_any(
+        &lower,
+        &[
+            "web development",
+            "frontend",
+            "backend",
+            "api",
+            "rest",
+            "graphql",
+            "http",
+            "server",
+            "client",
+            "browser",
+        ],
+    ) {
         signals.push(("interest".to_string(), "web_development".to_string()));
     }
 
     // Data science interest
-    if contains_any(&lower, &[
-        "data science", "data analysis", "statistics", "visualization",
-        "dataset", "data processing", "analytics",
-    ]) {
+    if contains_any(
+        &lower,
+        &[
+            "data science",
+            "data analysis",
+            "statistics",
+            "visualization",
+            "dataset",
+            "data processing",
+            "analytics",
+        ],
+    ) {
         signals.push(("interest".to_string(), "data_science".to_string()));
     }
 
@@ -109,16 +193,23 @@ mod tests {
 
     #[test]
     fn test_extract_software_development_signal() {
-        let response = "To debug this code, you should add logging statements before the function call.";
+        let response =
+            "To debug this code, you should add logging statements before the function call.";
         let signals = extract_identity_signals(response);
-        assert!(signals.contains(&("work_domain".to_string(), "software_development".to_string())));
+        assert!(signals.contains(&(
+            "work_domain".to_string(),
+            "software_development".to_string()
+        )));
     }
 
     #[test]
     fn test_extract_rust_tool_preference() {
         let response = "You can use tokio for async runtime in Rust. The borrow checker will ensure memory safety.";
         let signals = extract_identity_signals(response);
-        assert!(signals.contains(&("work_domain".to_string(), "software_development".to_string())));
+        assert!(signals.contains(&(
+            "work_domain".to_string(),
+            "software_development".to_string()
+        )));
         assert!(signals.contains(&("tool_preference".to_string(), "rust".to_string())));
         assert!(signals.contains(&("interest".to_string(), "systems_programming".to_string())));
     }
@@ -133,9 +224,13 @@ mod tests {
 
     #[test]
     fn test_extract_ai_ml_interest() {
-        let response = "The transformer model uses attention mechanisms for language understanding.";
+        let response =
+            "The transformer model uses attention mechanisms for language understanding.";
         let signals = extract_identity_signals(response);
-        assert!(signals.contains(&("interest".to_string(), "artificial_intelligence".to_string())));
+        assert!(signals.contains(&(
+            "interest".to_string(),
+            "artificial_intelligence".to_string()
+        )));
     }
 
     #[test]
@@ -168,9 +263,15 @@ mod tests {
     fn test_multiple_interests_combined() {
         let response = "You can build a web API that serves machine learning model predictions using Python and FastAPI.";
         let signals = extract_identity_signals(response);
-        assert!(signals.contains(&("work_domain".to_string(), "software_development".to_string())));
+        assert!(signals.contains(&(
+            "work_domain".to_string(),
+            "software_development".to_string()
+        )));
         assert!(signals.contains(&("tool_preference".to_string(), "python".to_string())));
-        assert!(signals.contains(&("interest".to_string(), "artificial_intelligence".to_string())));
+        assert!(signals.contains(&(
+            "interest".to_string(),
+            "artificial_intelligence".to_string()
+        )));
         assert!(signals.contains(&("interest".to_string(), "web_development".to_string())));
     }
 }

--- a/crates/memory/src/encrypted_store.rs
+++ b/crates/memory/src/encrypted_store.rs
@@ -1,6 +1,6 @@
 use crate::error::MemoryError;
-use crypto::MasterKey;
 use crypto::working_file;
+use crypto::MasterKey;
 use std::path::{Path, PathBuf};
 
 /// Manages encrypted storage for ech0's persistent files.

--- a/crates/runtime/src/boot.rs
+++ b/crates/runtime/src/boot.rs
@@ -276,10 +276,8 @@ pub async fn boot() -> Result<Runtime, BootError> {
 
     // Step 11: Speech actors (STT/TTS/Wakeword) — spawn only if onboarding succeeded.
     if speech_available {
-        let stt_backend = speech::SttBackend::Whisper;
-
         let stt_actor = speech::SttActor::new(
-            stt_backend,
+            config.stt_backend,
             config.voice_always_listening,
             config.stt_energy_threshold,
             config.whisper_model_path.clone(),

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
+use speech::SttBackend;
 
 /// Configuration for Sena runtime and subsystems.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -241,6 +242,12 @@ pub struct SenaConfig {
     /// and auto-downloads on first boot if the file is not present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embed_model_path: Option<PathBuf>,
+
+    /// STT backend selection.
+    /// Options: "whisper", "sherpa", "parakeet", "mock"
+    /// Default: "whisper"
+    #[serde(default = "default_stt_backend")]
+    pub stt_backend: SttBackend,
 }
 
 /// Configuration for the streaming inference pipeline.
@@ -310,6 +317,7 @@ impl Default for SenaConfig {
             vision_frame_max_age_secs: default_vision_frame_max_age_secs(),
             file_watch_exclude_patterns: default_file_watch_exclude_patterns(),
             embed_model_path: None,
+            stt_backend: default_stt_backend(),
         }
     }
 }
@@ -433,6 +441,9 @@ fn default_file_watch_exclude_patterns() -> Vec<String> {
     {
         vec![".git".to_string(), "node_modules".to_string()]
     }
+}
+fn default_stt_backend() -> SttBackend {
+    SttBackend::Whisper
 }
 
 /// Configuration-related errors.
@@ -610,6 +621,17 @@ pub async fn apply_config_set(key: &str, value: &str) -> Result<(), String> {
             } else {
                 Some(PathBuf::from(value))
             };
+            Ok(())
+        }
+        "stt_backend" => {
+            let backend = match value.to_lowercase().as_str() {
+                "whisper" => SttBackend::Whisper,
+                "sherpa" => SttBackend::Sherpa,
+                "parakeet" => SttBackend::Parakeet,
+                "mock" => SttBackend::Mock,
+                _ => return Err("expected one of: whisper, sherpa, parakeet, mock".to_string()),
+            };
+            config.stt_backend = backend;
             Ok(())
         }
         _ => Err(format!(

--- a/crates/runtime/src/ipc_server.rs
+++ b/crates/runtime/src/ipc_server.rs
@@ -986,6 +986,65 @@ async fn dispatch_slash_command(
                 )],
             }
         }
+        "/stt-backend" => {
+            match parts.get(1).copied() {
+                None => {
+                    // Show current backend + available options
+                    match crate::config::load_or_create_config().await {
+                        Ok(config) => {
+                            vec![
+                                ("━━  STT Backend".to_string(), LineStyle::SystemNotice),
+                                (
+                                    format!("Current: {:?}", config.stt_backend),
+                                    LineStyle::Normal,
+                                ),
+                                (
+                                    "Available: whisper, sherpa, parakeet".to_string(),
+                                    LineStyle::Normal,
+                                ),
+                                (
+                                    "Usage: /stt-backend <backend>".to_string(),
+                                    LineStyle::SystemNotice,
+                                ),
+                            ]
+                        }
+                        Err(e) => {
+                            vec![(format!("Failed to load config: {}", e), LineStyle::Error)]
+                        }
+                    }
+                }
+                Some(backend_str) => {
+                    // Validate backend name
+                    let backend = match backend_str.to_lowercase().as_str() {
+                        "whisper" | "sherpa" | "parakeet" => backend_str.to_lowercase(),
+                        _ => {
+                            return vec![(
+                                "Invalid backend. Use: whisper, sherpa, parakeet".to_string(),
+                                LineStyle::Error,
+                            )];
+                        }
+                    };
+
+                    // Broadcast switch request
+                    if let Err(e) = bus
+                        .broadcast(Event::Speech(SpeechEvent::SttBackendSwitchRequested {
+                            backend: backend.clone(),
+                        }))
+                        .await
+                    {
+                        vec![(
+                            format!("Failed to send backend switch request: {}", e),
+                            LineStyle::Error,
+                        )]
+                    } else {
+                        vec![(
+                            format!("Switching STT backend to {}...", backend),
+                            LineStyle::SystemNotice,
+                        )]
+                    }
+                }
+            }
+        }
         _ if line.starts_with('/') => {
             vec![(
                 format!("Unknown command '{}'. Type /help for commands.", cmd),
@@ -1307,13 +1366,7 @@ fn current_user_pipe_identity() -> Option<String> {
         }
 
         let mut bytes_needed: DWORD = 0;
-        let _ = GetTokenInformation(
-            token,
-            TokenUser,
-            ptr::null_mut(),
-            0,
-            &mut bytes_needed,
-        );
+        let _ = GetTokenInformation(token, TokenUser, ptr::null_mut(), 0, &mut bytes_needed);
 
         if bytes_needed == 0 {
             let _ = CloseHandle(token);

--- a/crates/runtime/src/ipc_server.rs
+++ b/crates/runtime/src/ipc_server.rs
@@ -805,6 +805,26 @@ async fn dispatch_slash_command(
                 LineStyle::SystemNotice,
             )]
         }
+        "/export" => {
+            let path = parts
+                .get(1)
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| std::path::PathBuf::from("sena-soul-export.json"));
+            if let Err(e) = bus
+                .broadcast(Event::Soul(SoulEvent::ExportRequested { path: path.clone() }))
+                .await
+            {
+                vec![(
+                    format!("Failed to request Soul export: {}", e),
+                    LineStyle::Error,
+                )]
+            } else {
+                vec![(
+                    format!("Requested Soul export to {}", path.display()),
+                    LineStyle::SystemNotice,
+                )]
+            }
+        }
         "/help" | "/h" => {
             vec![
                 ("━━  Commands".to_string(), LineStyle::SystemNotice),
@@ -835,6 +855,10 @@ async fn dispatch_slash_command(
                 ),
                 (
                     "/loops                 — Show and toggle background loops".to_string(),
+                    LineStyle::Normal,
+                ),
+                (
+                    "/export [path]         — Request Soul export (stub)".to_string(),
                     LineStyle::Normal,
                 ),
                 (

--- a/crates/runtime/src/supervisor.rs
+++ b/crates/runtime/src/supervisor.rs
@@ -12,7 +12,7 @@
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-use bus::{Event, InferenceEvent, SystemEvent};
+use bus::{Event, InferenceEvent, MemoryEvent, SpeechEvent, SystemEvent};
 
 use crate::analytics::TokenTuner;
 use crate::boot::{BootError, Runtime};
@@ -210,6 +210,29 @@ pub async fn supervision_loop(runtime: Runtime) -> Result<(), crate::shutdown::S
                                 }
                             }
                         }
+                    }
+                    Ok(Event::Speech(SpeechEvent::SttTelemetryUpdate {
+                        backend,
+                        vram_mb,
+                        latency_ms,
+                        avg_confidence,
+                        request_id,
+                    })) => {
+                        tracing::debug!(
+                            "runtime: stt telemetry backend={} request_id={} vram_mb={:?} latency_ms={:.2} avg_confidence={:.3}",
+                            backend,
+                            request_id,
+                            vram_mb,
+                            latency_ms,
+                            avg_confidence
+                        );
+                    }
+                    Ok(Event::Memory(MemoryEvent::SemanticIngestComplete(evt))) => {
+                        tracing::debug!(
+                            "runtime: semantic ingest complete node_id={} request_id={}",
+                            evt.node_id,
+                            evt.request_id
+                        );
                     }
                     Ok(Event::System(SystemEvent::ActorFailed(info))) => {
                         let count = failure_counts.entry(info.actor_name).or_insert(0);

--- a/crates/soul/src/actor.rs
+++ b/crates/soul/src/actor.rs
@@ -525,6 +525,11 @@ impl SoulActor {
         Ok(())
     }
 
+    fn handle_export_requested(&mut self, _path: std::path::PathBuf) -> Result<(), SoulError> {
+        // TODO: implement export logic.
+        Err(SoulError::NotImplemented("export".into()))
+    }
+
     /// Periodically harvest distilled signals and preferences.
     ///
     /// Called after every N absorbed events or explicitly after preference updates.
@@ -820,16 +825,12 @@ impl Actor for SoulActor {
                                     let _ = self.handle_rich_summary_requested(token_budget, request_id, &bus);
                                 }
                                 SoulEvent::PreferenceLearningUpdate { signal, .. } => {
+                                    // TODO M8.5: emitted by Soul pattern crystallization
+                                    // on UsagePatternUpdated — wire in Phase 8
                                     let _ = self.handle_preference_learning_update(&signal, &bus);
                                 }
                                 SoulEvent::ExportRequested { path } => {
-                                    // TODO M6: implement full export (event log + identity signals → JSON).
-                                    let _ = bus
-                                        .broadcast(Event::Soul(SoulEvent::ExportFailed {
-                                            reason: "Soul export not yet implemented (M6)".to_string(),
-                                        }))
-                                        .await;
-                                    let _ = path; // suppress unused warning until M6
+                                    let _ = self.handle_export_requested(path);
                                 }
                                 _ => {}
                             }

--- a/crates/soul/src/encrypted_db.rs
+++ b/crates/soul/src/encrypted_db.rs
@@ -1,6 +1,6 @@
 use crate::error::SoulError;
-use crypto::MasterKey;
 use crypto::working_file;
+use crypto::MasterKey;
 use std::path::{Path, PathBuf};
 
 #[cfg(test)]

--- a/crates/soul/src/error.rs
+++ b/crates/soul/src/error.rs
@@ -5,6 +5,9 @@ pub enum SoulError {
     #[error("database error: {0}")]
     Database(String),
 
+    #[error("not implemented: {0}")]
+    NotImplemented(String),
+
     #[error("encryption error: {0}")]
     Encryption(#[from] CryptoError),
 

--- a/crates/speech/Cargo.toml
+++ b/crates/speech/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { workspace = true, features = ["fs"] }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
 
 # Audio I/O (cross-platform)
 cpal = "0.15"

--- a/crates/speech/Cargo.toml
+++ b/crates/speech/Cargo.toml
@@ -35,7 +35,7 @@ byteorder = "1"
 serde_json = "1"
 
 # STT backend - sherpa-onnx Zipformer (fast streaming alternative to Whisper)
-sherpa-rs = { version = "0.6.8", features = ["download-binaries"] }
+sherpa-onnx = { version = "1.12.36", default-features = false, features = ["shared"] }
 
 # STT backend - NVIDIA Parakeet-EOU (ONNX streaming STT)
 parakeet-rs = "0.3.4"

--- a/crates/speech/Cargo.toml
+++ b/crates/speech/Cargo.toml
@@ -34,5 +34,8 @@ rand = { workspace = true }
 byteorder = "1"
 serde_json = "1"
 
+# STT backend - sherpa-onnx Zipformer (fast streaming alternative to Whisper)
+sherpa-rs = { version = "0.6.8", features = ["download-binaries"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/speech/Cargo.toml
+++ b/crates/speech/Cargo.toml
@@ -37,5 +37,8 @@ serde_json = "1"
 # STT backend - sherpa-onnx Zipformer (fast streaming alternative to Whisper)
 sherpa-rs = { version = "0.6.8", features = ["download-binaries"] }
 
+# STT backend - NVIDIA Parakeet-EOU (ONNX streaming STT)
+parakeet-rs = "0.3.4"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/speech/src/download.rs
+++ b/crates/speech/src/download.rs
@@ -257,8 +257,15 @@ impl ModelCache {
     }
 
     /// Returns the expected path for a cached model.
+    ///
+    /// Sherpa and Parakeet models are stored in subdirectories to avoid
+    /// naming collisions (e.g. both Whisper and Parakeet use `tokenizer.json`).
     pub fn cached_path(model_dir: &Path, model: &ModelInfo) -> PathBuf {
-        model_dir.join(&model.filename)
+        match model.model_type {
+            ModelType::SherpaZipformerStt => model_dir.join("sherpa").join(&model.filename),
+            ModelType::ParakeetStt => model_dir.join("parakeet").join(&model.filename),
+            _ => model_dir.join(&model.filename),
+        }
     }
 
     /// Lists all cached models in the directory.
@@ -364,12 +371,13 @@ impl DownloadClient {
         model: &ModelInfo,
         request_id: u64,
     ) -> Result<PathBuf, SpeechError> {
-        // Ensure model directory exists
-        fs::create_dir_all(model_dir)
+        let path = ModelCache::cached_path(model_dir, model);
+
+        // Ensure the target directory exists (may be a subdirectory for Sherpa/Parakeet models)
+        let target_dir = path.parent().unwrap_or(model_dir);
+        fs::create_dir_all(target_dir)
             .await
             .map_err(|e| SpeechError::DownloadFailed(format!("create dir: {}", e)))?;
-
-        let path = ModelCache::cached_path(model_dir, model);
         let temp_path = path.with_extension("tmp");
 
         tracing::info!(
@@ -510,7 +518,7 @@ mod tests {
     #[test]
     fn model_manifest_contains_all_models() {
         let models = ModelManifest::all_models();
-        assert_eq!(models.len(), 9);
+        assert_eq!(models.len(), 12);
 
         let whisper = &models[0];
         assert_eq!(whisper.model_type, ModelType::WhisperStt);
@@ -531,15 +539,39 @@ mod tests {
         let wakeword = &models[4];
         assert_eq!(wakeword.model_type, ModelType::OpenWakeWord);
         assert!(wakeword.filename.ends_with(".tflite"));
+
+        // Verify Sherpa and Parakeet models are present
+        let sherpa_count = models
+            .iter()
+            .filter(|m| m.model_type == ModelType::SherpaZipformerStt)
+            .count();
+        assert_eq!(sherpa_count, 4); // encoder, decoder, joiner, tokens
+
+        let parakeet_count = models
+            .iter()
+            .filter(|m| m.model_type == ModelType::ParakeetStt)
+            .count();
+        assert_eq!(parakeet_count, 3); // encoder, decoder_joint, tokenizer
     }
 
     #[test]
     fn cached_path_returns_correct_path() {
-        let model = ModelManifest::whisper_base_en_safetensors();
         let model_dir = Path::new("/tmp/models");
-        let path = ModelCache::cached_path(model_dir, &model);
 
-        assert_eq!(path, model_dir.join(&model.filename));
+        // Whisper model lands flat in model_dir
+        let whisper = ModelManifest::whisper_base_en_safetensors();
+        let path = ModelCache::cached_path(model_dir, &whisper);
+        assert_eq!(path, model_dir.join(&whisper.filename));
+
+        // Sherpa models land in model_dir/sherpa/
+        let sherpa = ModelManifest::sherpa_zipformer_encoder();
+        let path = ModelCache::cached_path(model_dir, &sherpa);
+        assert_eq!(path, model_dir.join("sherpa").join(&sherpa.filename));
+
+        // Parakeet models land in model_dir/parakeet/
+        let parakeet = ModelManifest::parakeet_eou_encoder();
+        let path = ModelCache::cached_path(model_dir, &parakeet);
+        assert_eq!(path, model_dir.join("parakeet").join(&parakeet.filename));
     }
 
     #[tokio::test]

--- a/crates/speech/src/download.rs
+++ b/crates/speech/src/download.rs
@@ -262,7 +262,7 @@ impl ModelCache {
     /// naming collisions (e.g. both Whisper and Parakeet use `tokenizer.json`).
     pub fn cached_path(model_dir: &Path, model: &ModelInfo) -> PathBuf {
         match model.model_type {
-            ModelType::SherpaZipformerStt => model_dir.join("sherpa").join(&model.filename),
+            ModelType::SherpaZipformerStt => model_dir.join("sherpa-streaming").join(&model.filename),
             ModelType::ParakeetStt => model_dir.join("parakeet").join(&model.filename),
             _ => model_dir.join(&model.filename),
         }
@@ -563,10 +563,10 @@ mod tests {
         let path = ModelCache::cached_path(model_dir, &whisper);
         assert_eq!(path, model_dir.join(&whisper.filename));
 
-        // Sherpa models land in model_dir/sherpa/
+        // Sherpa models land in model_dir/sherpa-streaming/
         let sherpa = ModelManifest::sherpa_zipformer_encoder();
         let path = ModelCache::cached_path(model_dir, &sherpa);
-        assert_eq!(path, model_dir.join("sherpa").join(&sherpa.filename));
+        assert_eq!(path, model_dir.join("sherpa-streaming").join(&sherpa.filename));
 
         // Parakeet models land in model_dir/parakeet/
         let parakeet = ModelManifest::parakeet_eou_encoder();

--- a/crates/speech/src/download.rs
+++ b/crates/speech/src/download.rs
@@ -27,6 +27,8 @@ pub enum ModelType {
     PiperTts,
     /// OpenWakeWord model for wakeword detection.
     OpenWakeWord,
+    /// Sherpa-onnx Zipformer model for STT.
+    SherpaZipformerStt,
 }
 
 /// Speech model information.
@@ -127,6 +129,54 @@ impl ModelManifest {
         }
     }
 
+    /// Returns the Zipformer encoder (int8 quantized, ~15MB).
+    pub fn sherpa_zipformer_encoder() -> ModelInfo {
+        ModelInfo {
+            name: "sherpa-zipformer-en-encoder-int8".to_string(),
+            filename: "sherpa_encoder.onnx".to_string(),
+            url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/encoder-epoch-99-avg-1.int8.onnx".to_string(),
+            sha256: CHECKSUM_UNKNOWN.to_string(),
+            size_bytes: 15_000_000,
+            model_type: ModelType::SherpaZipformerStt,
+        }
+    }
+
+    /// Returns the Zipformer decoder (int8 quantized, ~2MB).
+    pub fn sherpa_zipformer_decoder() -> ModelInfo {
+        ModelInfo {
+            name: "sherpa-zipformer-en-decoder-int8".to_string(),
+            filename: "sherpa_decoder.onnx".to_string(),
+            url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/decoder-epoch-99-avg-1.int8.onnx".to_string(),
+            sha256: CHECKSUM_UNKNOWN.to_string(),
+            size_bytes: 2_000_000,
+            model_type: ModelType::SherpaZipformerStt,
+        }
+    }
+
+    /// Returns the Zipformer joiner (int8 quantized, ~1MB).
+    pub fn sherpa_zipformer_joiner() -> ModelInfo {
+        ModelInfo {
+            name: "sherpa-zipformer-en-joiner-int8".to_string(),
+            filename: "sherpa_joiner.onnx".to_string(),
+            url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/joiner-epoch-99-avg-1.int8.onnx".to_string(),
+            sha256: CHECKSUM_UNKNOWN.to_string(),
+            size_bytes: 1_000_000,
+            model_type: ModelType::SherpaZipformerStt,
+        }
+    }
+
+    /// Returns the Zipformer token vocabulary (~10KB).
+    pub fn sherpa_zipformer_tokens() -> ModelInfo {
+        ModelInfo {
+            name: "sherpa-zipformer-en-tokens".to_string(),
+            filename: "sherpa_tokens.txt".to_string(),
+            url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/tokens.txt".to_string(),
+            sha256: CHECKSUM_UNKNOWN.to_string(),
+            size_bytes: 10_000,
+            model_type: ModelType::SherpaZipformerStt,
+        }
+    }
+
     /// Returns all known models.
     pub fn all_models() -> Vec<ModelInfo> {
         vec![
@@ -135,6 +185,10 @@ impl ModelManifest {
             Self::whisper_tokenizer(),
             Self::piper_voice(),
             Self::open_wakeword(),
+            Self::sherpa_zipformer_encoder(),
+            Self::sherpa_zipformer_decoder(),
+            Self::sherpa_zipformer_joiner(),
+            Self::sherpa_zipformer_tokens(),
         ]
     }
 }
@@ -415,7 +469,7 @@ mod tests {
     #[test]
     fn model_manifest_contains_all_models() {
         let models = ModelManifest::all_models();
-        assert_eq!(models.len(), 5);
+        assert_eq!(models.len(), 9);
 
         let whisper = &models[0];
         assert_eq!(whisper.model_type, ModelType::WhisperStt);

--- a/crates/speech/src/download.rs
+++ b/crates/speech/src/download.rs
@@ -136,21 +136,21 @@ impl ModelManifest {
         ModelInfo {
             name: "sherpa-zipformer-en-encoder-int8".to_string(),
             filename: "encoder-epoch-99-avg-1.int8.onnx".to_string(),
-            url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/encoder-epoch-99-avg-1.int8.onnx".to_string(),
+            url: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-02-21/resolve/main/encoder-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
-            size_bytes: 188_000_000,
+            size_bytes: 127_000_000,
             model_type: ModelType::SherpaZipformerStt,
         }
     }
 
-    /// Returns the Zipformer decoder (int8 quantized, ~539KB).
+    /// Returns the Zipformer decoder (int8 quantized, ~541KB).
     pub fn sherpa_zipformer_decoder() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-decoder-int8".to_string(),
             filename: "decoder-epoch-99-avg-1.int8.onnx".to_string(),
-            url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/decoder-epoch-99-avg-1.int8.onnx".to_string(),
+            url: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-02-21/resolve/main/decoder-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
-            size_bytes: 539_000,
+            size_bytes: 541_000,
             model_type: ModelType::SherpaZipformerStt,
         }
     }
@@ -160,7 +160,7 @@ impl ModelManifest {
         ModelInfo {
             name: "sherpa-zipformer-en-joiner-int8".to_string(),
             filename: "joiner-epoch-99-avg-1.int8.onnx".to_string(),
-            url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/joiner-epoch-99-avg-1.int8.onnx".to_string(),
+            url: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-02-21/resolve/main/joiner-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
             size_bytes: 259_000,
             model_type: ModelType::SherpaZipformerStt,
@@ -172,7 +172,7 @@ impl ModelManifest {
         ModelInfo {
             name: "sherpa-zipformer-en-tokens".to_string(),
             filename: "tokens.txt".to_string(),
-            url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/tokens.txt".to_string(),
+            url: "https://huggingface.co/csukuangfj/sherpa-onnx-streaming-zipformer-en-2023-02-21/resolve/main/tokens.txt".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
             size_bytes: 5_050,
             model_type: ModelType::SherpaZipformerStt,

--- a/crates/speech/src/download.rs
+++ b/crates/speech/src/download.rs
@@ -129,50 +129,50 @@ impl ModelManifest {
         }
     }
 
-    /// Returns the Zipformer encoder (int8 quantized, ~15MB).
+    /// Returns the Zipformer encoder (int8 quantized, ~188MB).
     pub fn sherpa_zipformer_encoder() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-encoder-int8".to_string(),
             filename: "sherpa_encoder.onnx".to_string(),
             url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/encoder-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
-            size_bytes: 15_000_000,
+            size_bytes: 188_000_000,
             model_type: ModelType::SherpaZipformerStt,
         }
     }
 
-    /// Returns the Zipformer decoder (int8 quantized, ~2MB).
+    /// Returns the Zipformer decoder (int8 quantized, ~539KB).
     pub fn sherpa_zipformer_decoder() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-decoder-int8".to_string(),
             filename: "sherpa_decoder.onnx".to_string(),
             url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/decoder-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
-            size_bytes: 2_000_000,
+            size_bytes: 539_000,
             model_type: ModelType::SherpaZipformerStt,
         }
     }
 
-    /// Returns the Zipformer joiner (int8 quantized, ~1MB).
+    /// Returns the Zipformer joiner (int8 quantized, ~259KB).
     pub fn sherpa_zipformer_joiner() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-joiner-int8".to_string(),
             filename: "sherpa_joiner.onnx".to_string(),
             url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/joiner-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
-            size_bytes: 1_000_000,
+            size_bytes: 259_000,
             model_type: ModelType::SherpaZipformerStt,
         }
     }
 
-    /// Returns the Zipformer token vocabulary (~10KB).
+    /// Returns the Zipformer token vocabulary (~5KB).
     pub fn sherpa_zipformer_tokens() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-tokens".to_string(),
             filename: "sherpa_tokens.txt".to_string(),
             url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/tokens.txt".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
-            size_bytes: 10_000,
+            size_bytes: 5_050,
             model_type: ModelType::SherpaZipformerStt,
         }
     }

--- a/crates/speech/src/download.rs
+++ b/crates/speech/src/download.rs
@@ -29,6 +29,8 @@ pub enum ModelType {
     OpenWakeWord,
     /// Sherpa-onnx Zipformer model for STT.
     SherpaZipformerStt,
+    /// NVIDIA Parakeet model for STT.
+    ParakeetStt,
 }
 
 /// Speech model information.
@@ -133,7 +135,7 @@ impl ModelManifest {
     pub fn sherpa_zipformer_encoder() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-encoder-int8".to_string(),
-            filename: "sherpa_encoder.onnx".to_string(),
+            filename: "encoder-epoch-99-avg-1.int8.onnx".to_string(),
             url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/encoder-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
             size_bytes: 188_000_000,
@@ -145,7 +147,7 @@ impl ModelManifest {
     pub fn sherpa_zipformer_decoder() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-decoder-int8".to_string(),
-            filename: "sherpa_decoder.onnx".to_string(),
+            filename: "decoder-epoch-99-avg-1.int8.onnx".to_string(),
             url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/decoder-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
             size_bytes: 539_000,
@@ -157,7 +159,7 @@ impl ModelManifest {
     pub fn sherpa_zipformer_joiner() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-joiner-int8".to_string(),
-            filename: "sherpa_joiner.onnx".to_string(),
+            filename: "joiner-epoch-99-avg-1.int8.onnx".to_string(),
             url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/joiner-epoch-99-avg-1.int8.onnx".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
             size_bytes: 259_000,
@@ -169,11 +171,47 @@ impl ModelManifest {
     pub fn sherpa_zipformer_tokens() -> ModelInfo {
         ModelInfo {
             name: "sherpa-zipformer-en-tokens".to_string(),
-            filename: "sherpa_tokens.txt".to_string(),
+            filename: "tokens.txt".to_string(),
             url: "https://huggingface.co/csukuangfj/sherpa-onnx-zipformer-en-2023-04-01/resolve/main/tokens.txt".to_string(),
             sha256: CHECKSUM_UNKNOWN.to_string(),
             size_bytes: 5_050,
             model_type: ModelType::SherpaZipformerStt,
+        }
+    }
+
+    /// Returns the Parakeet encoder ONNX file (~243MB).
+    pub fn parakeet_eou_encoder() -> ModelInfo {
+        ModelInfo {
+            name: "parakeet-eou-encoder".to_string(),
+            filename: "encoder.onnx".to_string(),
+            url: "https://huggingface.co/altunenes/parakeet-rs/resolve/main/realtime_eou_120m-v1-onnx/encoder.onnx".to_string(),
+            sha256: "d472887cc38a784a5bfc21c2dbe247639edc3b3f9992388d8ceceaec07256b5b".to_string(),
+            size_bytes: 243_000_000,
+            model_type: ModelType::ParakeetStt,
+        }
+    }
+
+    /// Returns the Parakeet decoder_joint ONNX file (~235MB).
+    pub fn parakeet_eou_decoder_joint() -> ModelInfo {
+        ModelInfo {
+            name: "parakeet-eou-decoder-joint".to_string(),
+            filename: "decoder_joint.onnx".to_string(),
+            url: "https://huggingface.co/altunenes/parakeet-rs/resolve/main/realtime_eou_120m-v1-onnx/decoder_joint.onnx".to_string(),
+            sha256: "9d2553ac043c2fc5f69e970769b0fb8ab9103fbfdeb7d26a1ea9729d4bd2dddd".to_string(),
+            size_bytes: 235_000_000,
+            model_type: ModelType::ParakeetStt,
+        }
+    }
+
+    /// Returns the Parakeet tokenizer JSON file (~2MB).
+    pub fn parakeet_eou_tokenizer() -> ModelInfo {
+        ModelInfo {
+            name: "parakeet-eou-tokenizer".to_string(),
+            filename: "tokenizer.json".to_string(),
+            url: "https://huggingface.co/altunenes/parakeet-rs/resolve/main/realtime_eou_120m-v1-onnx/tokenizer.json".to_string(),
+            sha256: CHECKSUM_UNKNOWN.to_string(),
+            size_bytes: 2_000_000,
+            model_type: ModelType::ParakeetStt,
         }
     }
 
@@ -189,6 +227,9 @@ impl ModelManifest {
             Self::sherpa_zipformer_decoder(),
             Self::sherpa_zipformer_joiner(),
             Self::sherpa_zipformer_tokens(),
+            Self::parakeet_eou_encoder(),
+            Self::parakeet_eou_decoder_joint(),
+            Self::parakeet_eou_tokenizer(),
         ]
     }
 }

--- a/crates/speech/src/error.rs
+++ b/crates/speech/src/error.rs
@@ -51,4 +51,8 @@ pub enum SpeechError {
     /// Model not found in manifest.
     #[error("model not found: {0}")]
     ModelNotFound(String),
+
+    /// Telemetry write failed.
+    #[error("telemetry write failed: {0}")]
+    TelemetryWriteFailed(String),
 }

--- a/crates/speech/src/lib.rs
+++ b/crates/speech/src/lib.rs
@@ -32,6 +32,8 @@ pub use telemetry::log_stt_telemetry;
 pub use tts_actor::TtsActor;
 pub use wakeword::WakewordActor;
 
+use serde::{Deserialize, Serialize};
+
 /// Audio buffer for PCM samples.
 #[derive(Debug, Clone)]
 pub struct AudioBuffer {
@@ -44,7 +46,8 @@ pub struct AudioBuffer {
 }
 
 /// STT backend selection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum SttBackend {
     /// Whisper via candle (STT).
     Whisper,

--- a/crates/speech/src/lib.rs
+++ b/crates/speech/src/lib.rs
@@ -25,6 +25,7 @@ pub mod wakeword;
 pub use audio_input::list_input_devices;
 pub use error::SpeechError;
 pub use parakeet_stt::ParakeetStt;
+pub use sherpa_stt::SherpaZipformerStt;
 pub use stt_actor::SttActor;
 pub use tts_actor::TtsActor;
 pub use wakeword::WakewordActor;

--- a/crates/speech/src/lib.rs
+++ b/crates/speech/src/lib.rs
@@ -15,6 +15,7 @@ mod candle_whisper;
 pub mod download;
 pub mod error;
 pub mod onboarding;
+mod sherpa_stt;
 mod silence_detector;
 pub mod stt_actor;
 pub mod tts_actor;

--- a/crates/speech/src/lib.rs
+++ b/crates/speech/src/lib.rs
@@ -43,6 +43,10 @@ pub struct AudioBuffer {
 pub enum SttBackend {
     /// Whisper via candle (STT).
     Whisper,
+    /// Sherpa-onnx Zipformer streaming STT (ONNX, <600MB VRAM).
+    Sherpa,
+    /// NVIDIA Parakeet streaming STT (.nemo, 1.2-2GB VRAM recommended).
+    Parakeet,
     /// Mock backend for testing.
     Mock,
 }

--- a/crates/speech/src/lib.rs
+++ b/crates/speech/src/lib.rs
@@ -15,6 +15,7 @@ mod candle_whisper;
 pub mod download;
 pub mod error;
 pub mod onboarding;
+mod parakeet_stt;
 mod sherpa_stt;
 mod silence_detector;
 pub mod stt_actor;
@@ -23,6 +24,7 @@ pub mod wakeword;
 
 pub use audio_input::list_input_devices;
 pub use error::SpeechError;
+pub use parakeet_stt::ParakeetStt;
 pub use stt_actor::SttActor;
 pub use tts_actor::TtsActor;
 pub use wakeword::WakewordActor;
@@ -45,7 +47,7 @@ pub enum SttBackend {
     Whisper,
     /// Sherpa-onnx Zipformer streaming STT (ONNX, <600MB VRAM).
     Sherpa,
-    /// NVIDIA Parakeet streaming STT (.nemo, 1.2-2GB VRAM recommended).
+    /// NVIDIA Parakeet streaming STT (ONNX format, 1.2-2GB VRAM recommended).
     Parakeet,
     /// Mock backend for testing.
     Mock,

--- a/crates/speech/src/lib.rs
+++ b/crates/speech/src/lib.rs
@@ -19,6 +19,7 @@ mod parakeet_stt;
 mod sherpa_stt;
 mod silence_detector;
 pub mod stt_actor;
+pub mod telemetry;
 pub mod tts_actor;
 pub mod wakeword;
 
@@ -27,6 +28,7 @@ pub use error::SpeechError;
 pub use parakeet_stt::ParakeetStt;
 pub use sherpa_stt::SherpaZipformerStt;
 pub use stt_actor::SttActor;
+pub use telemetry::log_stt_telemetry;
 pub use tts_actor::TtsActor;
 pub use wakeword::WakewordActor;
 

--- a/crates/speech/src/parakeet_stt.rs
+++ b/crates/speech/src/parakeet_stt.rs
@@ -35,16 +35,22 @@ impl ParakeetStt {
     ///
     /// Audio is converted from i16 to f32 normalized to [-1.0, 1.0] before processing.
     pub fn decode_chunk(&mut self, audio: &[i16]) -> Result<String, SpeechError> {
+        let audio_f32: Vec<f32> = audio.iter().map(|&s| s as f32 / 32768.0).collect();
+        self.decode_chunk_f32(&audio_f32)
+    }
+
+    /// Decode a chunk of f32 audio samples at 16kHz mono and return transcribed text.
+    ///
+    /// Preferred over `decode_chunk` for streaming paths — avoids the lossy i16 round-trip.
+    /// Feed exactly 2560 samples (160ms) per call for proper streaming behaviour.
+    pub fn decode_chunk_f32(&mut self, audio: &[f32]) -> Result<String, SpeechError> {
         tracing::debug!("parakeet: decoding {} samples", audio.len());
 
-        // Convert i16 samples to f32 normalized to [-1.0, 1.0]
-        let audio_f32: Vec<f32> = audio.iter().map(|&s| s as f32 / 32768.0).collect();
-
-        // transcribe() expects f32 samples and end_of_stream flag
-        // false = not end of stream, this is a chunk in a continuous stream
+        // transcribe() expects f32 samples and reset_on_eou flag.
+        // false = do not reset decoder state on EOU token, keep streaming.
         let text = self
             .model
-            .transcribe(&audio_f32, false)
+            .transcribe(audio, false)
             .map_err(|e| SpeechError::TranscriptionFailed(format!("parakeet decode: {}", e)))?;
 
         if !text.trim().is_empty() {

--- a/crates/speech/src/parakeet_stt.rs
+++ b/crates/speech/src/parakeet_stt.rs
@@ -44,6 +44,12 @@ impl ParakeetStt {
     /// Preferred over `decode_chunk` for streaming paths — avoids the lossy i16 round-trip.
     /// Feed exactly 2560 samples (160ms) per call for proper streaming behaviour.
     pub fn decode_chunk_f32(&mut self, audio: &[f32]) -> Result<String, SpeechError> {
+        if audio.len() != 2560 {
+            tracing::warn!(
+                "parakeet: expected 2560 samples (160ms at 16kHz), got {} — model output may be degraded",
+                audio.len()
+            );
+        }
         tracing::debug!("parakeet: decoding {} samples", audio.len());
 
         // transcribe() expects f32 samples and reset_on_eou flag.

--- a/crates/speech/src/parakeet_stt.rs
+++ b/crates/speech/src/parakeet_stt.rs
@@ -1,0 +1,63 @@
+//! NVIDIA Parakeet-EOU STT backend for streaming transcription.
+//!
+//! Wraps parakeet-rs::ParakeetEOU (ONNX-based streaming STT).
+//! Called synchronously — callers must use spawn_blocking or a worker thread.
+
+use crate::error::SpeechError;
+use parakeet_rs::ParakeetEOU;
+use std::path::Path;
+
+/// Parakeet-EOU STT state, owns the loaded ONNX model.
+pub struct ParakeetStt {
+    model: ParakeetEOU,
+}
+
+impl ParakeetStt {
+    /// Load the Parakeet-EOU model from an ONNX model directory.
+    /// This is a blocking operation — call from spawn_blocking or a dedicated thread.
+    ///
+    /// Expected files in `model_dir`:
+    ///   - `encoder.onnx`
+    ///   - `decoder_joint.onnx`
+    ///   - `tokenizer.json`
+    pub fn load(model_dir: &Path) -> Result<Self, SpeechError> {
+        tracing::debug!("loading parakeet-eou model from {}", model_dir.display());
+
+        let model = ParakeetEOU::from_pretrained(model_dir, None)
+            .map_err(|e| SpeechError::SttInitFailed(format!("parakeet model load: {}", e)))?;
+
+        tracing::info!("parakeet-eou model loaded from {}", model_dir.display());
+        Ok(Self { model })
+    }
+
+    /// Decode a chunk of i16 PCM audio samples at 16kHz mono and return transcribed text.
+    /// This is a blocking operation.
+    ///
+    /// Audio is converted from i16 to f32 normalized to [-1.0, 1.0] before processing.
+    pub fn decode_chunk(&mut self, audio: &[i16]) -> Result<String, SpeechError> {
+        tracing::debug!("parakeet: decoding {} samples", audio.len());
+
+        // Convert i16 samples to f32 normalized to [-1.0, 1.0]
+        let audio_f32: Vec<f32> = audio.iter().map(|&s| s as f32 / 32768.0).collect();
+
+        // transcribe() expects f32 samples and end_of_stream flag
+        // false = not end of stream, this is a chunk in a continuous stream
+        let text = self
+            .model
+            .transcribe(&audio_f32, false)
+            .map_err(|e| SpeechError::TranscriptionFailed(format!("parakeet decode: {}", e)))?;
+
+        if !text.trim().is_empty() {
+            tracing::debug!("parakeet: transcribed \"{}\"", text.trim());
+        }
+
+        Ok(text)
+    }
+
+    /// Returns true if all required Parakeet ONNX model files exist in the given directory.
+    pub fn models_present(model_dir: &Path) -> bool {
+        model_dir.join("encoder.onnx").exists()
+            && model_dir.join("decoder_joint.onnx").exists()
+            && model_dir.join("tokenizer.json").exists()
+    }
+}

--- a/crates/speech/src/sherpa_stt.rs
+++ b/crates/speech/src/sherpa_stt.rs
@@ -1,48 +1,89 @@
-//! Sherpa-onnx Zipformer STT backend for listen mode.
+//! Sherpa-onnx Zipformer STT backend for streaming transcription.
 //!
-//! Wraps sherpa_rs::zipformer::ZipFormer (offline transducer model).
+//! Wraps sherpa-onnx OnlineRecognizer (ONNX Zipformer Transducer model).
 //! Called synchronously — callers must use spawn_blocking or a worker thread.
 
 use crate::error::SpeechError;
-use sherpa_rs::zipformer::{ZipFormer, ZipFormerConfig};
 use std::path::Path;
 
-/// sherpa-onnx Zipformer STT state, owns the loaded model.
-pub(crate) struct SherpaZipformerStt {
-    model: ZipFormer,
+/// Sherpa-onnx Zipformer STT state, owns the loaded model and stream.
+pub struct SherpaZipformerStt {
+    recognizer: sherpa_onnx::OnlineRecognizer,
+    stream: sherpa_onnx::OnlineStream,
 }
 
 impl SherpaZipformerStt {
     /// Load the Zipformer model from ONNX files.
     /// This is a blocking operation — call from spawn_blocking or a dedicated thread.
-    pub(crate) fn load(
+    ///
+    /// Expected files:
+    ///   - encoder.onnx (or encoder.int8.onnx for quantized)
+    ///   - decoder.onnx
+    ///   - joiner.onnx (or joiner.int8.onnx for quantized)
+    ///   - tokens.txt
+    pub fn load(
         encoder: &str,
         decoder: &str,
         joiner: &str,
         tokens: &str,
     ) -> Result<Self, SpeechError> {
-        let config = ZipFormerConfig {
-            encoder: encoder.to_string(),
-            decoder: decoder.to_string(),
-            joiner: joiner.to_string(),
-            tokens: tokens.to_string(),
-            num_threads: Some(2),
-            provider: None,
-            debug: false,
-        };
-        let model =
-            ZipFormer::new(config).map_err(|e| SpeechError::SttInitFailed(e.to_string()))?;
-        Ok(Self { model })
+        tracing::debug!(
+            "loading sherpa-onnx zipformer model: encoder={}, decoder={}, joiner={}, tokens={}",
+            encoder,
+            decoder,
+            joiner,
+            tokens
+        );
+
+        let mut config = sherpa_onnx::OnlineRecognizerConfig::default();
+        config.model_config.transducer.encoder = Some(encoder.to_string());
+        config.model_config.transducer.decoder = Some(decoder.to_string());
+        config.model_config.transducer.joiner = Some(joiner.to_string());
+        config.model_config.tokens = Some(tokens.to_string());
+        config.enable_endpoint = true;
+        config.decoding_method = Some("greedy_search".to_string());
+
+        let recognizer = sherpa_onnx::OnlineRecognizer::create(&config).ok_or_else(|| {
+            SpeechError::SttInitFailed("sherpa-onnx OnlineRecognizer creation failed".to_string())
+        })?;
+
+        let stream = recognizer.create_stream();
+
+        tracing::info!("sherpa-onnx zipformer model loaded successfully");
+        Ok(Self { recognizer, stream })
     }
 
     /// Decode a batch of f32 samples at 16kHz mono and return the transcribed text.
     /// This is a blocking operation.
-    pub(crate) fn decode_chunk(&mut self, samples: Vec<f32>) -> String {
-        self.model.decode(16000, samples)
+    ///
+    /// Audio is expected to be f32 samples normalized to [-1.0, 1.0].
+    pub fn decode_chunk(&mut self, samples: Vec<f32>) -> String {
+        tracing::debug!("sherpa-onnx: decoding {} samples", samples.len());
+
+        // Feed audio to stream (16kHz assumed)
+        self.stream.accept_waveform(16000, &samples);
+
+        // Decode
+        while self.recognizer.is_ready(&self.stream) {
+            self.recognizer.decode(&self.stream);
+        }
+
+        // Get result
+        let text = self
+            .recognizer
+            .get_result(&self.stream)
+            .map(|result| result.text)
+            .unwrap_or_default();
+
+        if !text.trim().is_empty() {
+            tracing::debug!("sherpa-onnx: transcribed \"{}\"", text.trim());
+        }
+
+        text
     }
 
-    /// Returns true if all four model files exist in the given directory.
-    pub(crate) fn models_present(model_dir: &Path) -> bool {
+    /// Returns true if all required Sherpa ONNX model files exist in the given directory.
+    pub fn models_present(model_dir: &Path) -> bool {
         model_dir.join("sherpa_encoder.onnx").exists()
             && model_dir.join("sherpa_decoder.onnx").exists()
             && model_dir.join("sherpa_joiner.onnx").exists()

--- a/crates/speech/src/sherpa_stt.rs
+++ b/crates/speech/src/sherpa_stt.rs
@@ -82,6 +82,15 @@ impl SherpaZipformerStt {
         text
     }
 
+    /// Reset the internal stream state for a new utterance or new listen session.
+    ///
+    /// Call this between independent transcription sessions so previous
+    /// decoder state does not bleed into the next utterance.
+    pub fn reset_stream(&mut self) {
+        self.stream = self.recognizer.create_stream();
+        tracing::debug!("sherpa-onnx: stream reset for new session");
+    }
+
     /// Returns true if all required Sherpa ONNX model files exist in the given directory.
     pub fn models_present(model_dir: &Path) -> bool {
         model_dir.join("encoder-epoch-99-avg-1.int8.onnx").exists()

--- a/crates/speech/src/sherpa_stt.rs
+++ b/crates/speech/src/sherpa_stt.rs
@@ -1,0 +1,51 @@
+//! Sherpa-onnx Zipformer STT backend for listen mode.
+//!
+//! Wraps sherpa_rs::zipformer::ZipFormer (offline transducer model).
+//! Called synchronously — callers must use spawn_blocking or a worker thread.
+
+use crate::error::SpeechError;
+use sherpa_rs::zipformer::{ZipFormer, ZipFormerConfig};
+use std::path::Path;
+
+/// sherpa-onnx Zipformer STT state, owns the loaded model.
+pub(crate) struct SherpaZipformerStt {
+    model: ZipFormer,
+}
+
+impl SherpaZipformerStt {
+    /// Load the Zipformer model from ONNX files.
+    /// This is a blocking operation — call from spawn_blocking or a dedicated thread.
+    pub(crate) fn load(
+        encoder: &str,
+        decoder: &str,
+        joiner: &str,
+        tokens: &str,
+    ) -> Result<Self, SpeechError> {
+        let config = ZipFormerConfig {
+            encoder: encoder.to_string(),
+            decoder: decoder.to_string(),
+            joiner: joiner.to_string(),
+            tokens: tokens.to_string(),
+            num_threads: Some(2),
+            provider: None,
+            debug: false,
+        };
+        let model =
+            ZipFormer::new(config).map_err(|e| SpeechError::SttInitFailed(e.to_string()))?;
+        Ok(Self { model })
+    }
+
+    /// Decode a batch of f32 samples at 16kHz mono and return the transcribed text.
+    /// This is a blocking operation.
+    pub(crate) fn decode_chunk(&mut self, samples: Vec<f32>) -> String {
+        self.model.decode(16000, samples)
+    }
+
+    /// Returns true if all four model files exist in the given directory.
+    pub(crate) fn models_present(model_dir: &Path) -> bool {
+        model_dir.join("sherpa_encoder.onnx").exists()
+            && model_dir.join("sherpa_decoder.onnx").exists()
+            && model_dir.join("sherpa_joiner.onnx").exists()
+            && model_dir.join("sherpa_tokens.txt").exists()
+    }
+}

--- a/crates/speech/src/sherpa_stt.rs
+++ b/crates/speech/src/sherpa_stt.rs
@@ -84,9 +84,9 @@ impl SherpaZipformerStt {
 
     /// Returns true if all required Sherpa ONNX model files exist in the given directory.
     pub fn models_present(model_dir: &Path) -> bool {
-        model_dir.join("sherpa_encoder.onnx").exists()
-            && model_dir.join("sherpa_decoder.onnx").exists()
-            && model_dir.join("sherpa_joiner.onnx").exists()
-            && model_dir.join("sherpa_tokens.txt").exists()
+        model_dir.join("encoder-epoch-99-avg-1.int8.onnx").exists()
+            && model_dir.join("decoder-epoch-99-avg-1.int8.onnx").exists()
+            && model_dir.join("joiner-epoch-99-avg-1.int8.onnx").exists()
+            && model_dir.join("tokens.txt").exists()
     }
 }

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -15,6 +15,18 @@ use crate::{AudioBuffer, SpeechError, SttBackend};
 const TRANSCRIPTION_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_BUFFER_DURATION_SECS: f32 = 3.0;
 
+/// Audio chunk duration for Whisper fake-streaming /listen sessions (1s for responsiveness).
+const LISTEN_WHISPER_BUFFER_DURATION_SECS: f32 = 1.0;
+
+/// Maximum rolling audio retained for listen-mode interim transcriptions (6 seconds at 16kHz).
+const LISTEN_ROLLING_MAX_SAMPLES: usize = 16_000 * 6;
+
+/// Minimum audio accumulated before first interim transcription attempt (2s at 16kHz).
+const LISTEN_INTERIM_MIN_SAMPLES: usize = 16_000 * 2;
+
+/// How often to emit interim (non-final) transcriptions during Whisper listen mode.
+const LISTEN_INTERIM_INTERVAL: Duration = Duration::from_millis(1500);
+
 /// STT Actor - handles speech-to-text transcription.
 ///
 /// Pipeline:
@@ -53,6 +65,10 @@ pub struct SttActor {
     microphone_device: Option<String>,
     /// Whether the speech loop is enabled (pause/resume via LoopControlRequested).
     speech_loop_enabled: bool,
+    /// Rolling audio accumulator for Whisper fake-streaming interim transcriptions.
+    listen_rolling_samples: Vec<f32>,
+    /// Time of last interim Whisper transcription in listen mode.
+    listen_last_interim: Option<std::time::Instant>,
 }
 
 impl SttActor {
@@ -91,6 +107,8 @@ impl SttActor {
             listen_mode_active: false,
             microphone_device: None,
             speech_loop_enabled: true,
+            listen_rolling_samples: Vec::new(),
+            listen_last_interim: None,
         }
     }
 
@@ -270,33 +288,77 @@ impl SttActor {
 
     /// Handle an audio buffer for continuous listen mode.
     ///
-    /// Emits `ListenModeTranscription` with `is_final=false` for low-energy buffers and
-    /// `is_final=true` after silence-threshold silence within the session.
+    /// Implements Whisper fake-streaming via a sliding window:
+    /// - Every 1.5s, runs Whisper on the accumulated rolling audio → emits `is_final=false`
+    /// - When VAD detects end-of-speech, runs Whisper once more → emits `is_final=true`
     async fn handle_listen_audio_buffer(
         &mut self,
         buffer: AudioBuffer,
         session_id: u64,
         bus: &Arc<EventBus>,
     ) {
-        if let Some(ready_buffer) =
-            self.listen_mode_vad
-                .feed(&buffer.samples, buffer.sample_rate, buffer.channels)
+        // Accumulate samples in rolling buffer (max 6s at 16kHz).
+        self.listen_rolling_samples
+            .extend_from_slice(&buffer.samples);
+        if self.listen_rolling_samples.len() > LISTEN_ROLLING_MAX_SAMPLES {
+            let excess = self.listen_rolling_samples.len() - LISTEN_ROLLING_MAX_SAMPLES;
+            self.listen_rolling_samples.drain(..excess);
+        }
+
+        // Emit interim (non-final) transcription every LISTEN_INTERIM_INTERVAL
+        // once at least 2s of audio has accumulated.
+        let enough_audio = self.listen_rolling_samples.len() >= LISTEN_INTERIM_MIN_SAMPLES;
+        let interval_elapsed = self
+            .listen_last_interim
+            .map(|t| t.elapsed() >= LISTEN_INTERIM_INTERVAL)
+            .unwrap_or(true);
+
+        if enough_audio && interval_elapsed {
+            let interim_buf = AudioBuffer {
+                samples: self.listen_rolling_samples.clone(),
+                sample_rate: buffer.sample_rate,
+                channels: buffer.channels,
+            };
+            self.listen_last_interim = Some(std::time::Instant::now());
+            match tokio::time::timeout(TRANSCRIPTION_TIMEOUT, self.transcribe(interim_buf)).await {
+                Ok(Ok(result)) if !result.text.trim().is_empty() => {
+                    let _ = bus
+                        .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                            text: result.text,
+                            is_final: false,
+                            confidence: result.confidence,
+                            session_id,
+                        }))
+                        .await;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => tracing::warn!("listen[interim]: error: {}", e),
+                Err(_) => tracing::warn!("listen[interim]: timeout"),
+            }
+        }
+
+        // VAD for final speech-end detection.
+        if let Some(ready_buffer) = self
+            .listen_mode_vad
+            .feed(&buffer.samples, buffer.sample_rate, buffer.channels)
         {
             match tokio::time::timeout(TRANSCRIPTION_TIMEOUT, self.transcribe(ready_buffer)).await {
-                Ok(Ok(result)) => {
-                    if !result.text.trim().is_empty() {
-                        let _ = bus
-                            .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
-                                text: result.text,
-                                is_final: true,
-                                confidence: result.confidence,
-                                session_id,
-                            }))
-                            .await;
-                    }
+                Ok(Ok(result)) if !result.text.trim().is_empty() => {
+                    let _ = bus
+                        .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                            text: result.text,
+                            is_final: true,
+                            confidence: result.confidence,
+                            session_id,
+                        }))
+                        .await;
+                    // Reset rolling state for next utterance.
+                    self.listen_rolling_samples.clear();
+                    self.listen_last_interim = None;
                 }
-                Ok(Err(e)) => tracing::warn!("listen: transcription error: {}", e),
-                Err(_) => tracing::warn!("listen: transcription timeout"),
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => tracing::warn!("listen[whisper]: transcription error: {}", e),
+                Err(_) => tracing::warn!("listen[whisper]: transcription timeout"),
             }
         }
     }
@@ -433,7 +495,7 @@ impl Actor for SttActor {
                             }
                             let config = AudioInputConfig {
                                 sample_rate: 16_000,
-                                buffer_duration_secs: DEFAULT_BUFFER_DURATION_SECS,
+                                buffer_duration_secs: LISTEN_WHISPER_BUFFER_DURATION_SECS,
                                 // Pass all audio to SilenceDetector - it handles
                                 // voice/silence classification internally.
                                 energy_threshold: 0.0,
@@ -449,9 +511,11 @@ impl Actor for SttActor {
                                     // unintended inference calls.
                                     self.listen_mode_active = true;
                                     self.always_listening_vad.reset();
-                                    // Reset listen mode VAD for a clean session.
+                                    // Reset listen mode VAD and rolling buffer for a clean session.
                                     self.listen_mode_vad.reset();
-                                    tracing::info!("listen: session {} started", session_id);
+                                    self.listen_rolling_samples.clear();
+                                    self.listen_last_interim = None;
+                                    tracing::info!("listen: session {} started (whisper fake-streaming)", session_id);
                                 }
                                 Err(e) => {
                                     tracing::error!("listen: failed to start audio capture: {}", e);
@@ -470,6 +534,8 @@ impl Actor for SttActor {
                                 self.listen_audio_stream = None;
                                 self.listen_mode_vad.reset();
                                 self.listen_mode_active = false;
+                                self.listen_rolling_samples.clear();
+                                self.listen_last_interim = None;
                                 tracing::info!("listen: session {} stopped", session_id);
                                 let _ = bus
                                     .broadcast(Event::Speech(SpeechEvent::ListenModeStopped {

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -84,6 +84,8 @@ pub struct SttActor {
     sherpa_listen_active: bool,
     /// Time of last sherpa decode in the current listen session.
     listen_last_sherpa: Option<std::time::Instant>,
+    /// True while a backend switch is in progress. Suppresses audio processing.
+    backend_switching: bool,
 }
 
 impl SttActor {
@@ -127,6 +129,7 @@ impl SttActor {
             sherpa_worker_tx: None,
             sherpa_listen_active: false,
             listen_last_sherpa: None,
+            backend_switching: false,
         }
     }
 
@@ -728,6 +731,41 @@ impl SttActor {
                 .await;
         }
     }
+
+    /// Convert a string backend name to SttBackend enum.
+    fn parse_backend_name(backend_str: &str) -> Result<SttBackend, String> {
+        match backend_str.to_lowercase().as_str() {
+            "whisper" => Ok(SttBackend::Whisper),
+            "sherpa" => Ok(SttBackend::Sherpa),
+            "parakeet" => Ok(SttBackend::Parakeet),
+            "mock" => Ok(SttBackend::Mock),
+            _ => Err(format!(
+                "unknown backend '{}', expected: whisper, sherpa, parakeet, mock",
+                backend_str
+            )),
+        }
+    }
+
+    /// Shut down a backend handle gracefully.
+    async fn shutdown_backend(handle: SttBackendHandle) -> Result<(), SpeechError> {
+        match handle {
+            SttBackendHandle::CandleWhisper { tx } => {
+                tx.send(WorkerCommand::Shutdown).map_err(|_| {
+                    SpeechError::ChannelClosed("whisper worker tx closed".to_string())
+                })?;
+            }
+            SttBackendHandle::Sherpa { tx } => {
+                // Ignore send errors, channel may already be closed.
+                let _ = tx.send(SherpaCmd::Shutdown);
+            }
+            SttBackendHandle::Parakeet { tx } => {
+                // Ignore send errors, channel may already be closed.
+                let _ = tx.send(ParakeetCommand::Shutdown);
+            }
+            SttBackendHandle::Mock => {}
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -934,6 +972,72 @@ impl Actor for SttActor {
                                     .await;
                             }
                         }
+                        Ok(Event::Speech(SpeechEvent::SttBackendSwitchRequested { backend })) => {
+                            tracing::info!("stt: backend switch requested to '{}'", backend);
+
+                            // Parse backend name
+                            let new_backend = match Self::parse_backend_name(&backend) {
+                                Ok(b) => b,
+                                Err(e) => {
+                                    tracing::warn!("stt: invalid backend name: {}", e);
+                                    let _ = bus.broadcast(Event::Speech(SpeechEvent::SttBackendSwitchFailed {
+                                        backend: backend.clone(),
+                                        reason: e,
+                                    })).await;
+                                    continue;
+                                }
+                            };
+
+                            // Set switching flag to pause audio processing
+                            self.backend_switching = true;
+
+                            // Preserve old backend for rollback
+                            let old_backend = self.backend;
+                            let old_backend_handle = self.backend_handle.take();
+
+                            // Shut down current backend
+                            if let Some(handle) = old_backend_handle {
+                                tracing::debug!("stt: shutting down current backend");
+                                if let Err(e) = Self::shutdown_backend(handle).await {
+                                    tracing::warn!("stt: error shutting down old backend: {}", e);
+                                }
+                            }
+
+                            // Update backend enum
+                            self.backend = new_backend;
+
+                            // Try to initialize new backend
+                            match self.initialize_backend().await {
+                                Ok(()) => {
+                                    tracing::info!("stt: backend switched to {:?}", new_backend);
+                                    let _ = bus.broadcast(Event::Speech(SpeechEvent::SttBackendSwitchCompleted {
+                                        backend: backend.clone(),
+                                    })).await;
+                                }
+                                Err(e) => {
+                                    tracing::warn!("stt: backend switch failed ({}), rolling back to {:?}", e, old_backend);
+
+                                    // Rollback to old backend
+                                    self.backend = old_backend;
+                                    match self.initialize_backend().await {
+                                        Ok(()) => {
+                                            tracing::info!("stt: rollback to {:?} successful", old_backend);
+                                        }
+                                        Err(rollback_err) => {
+                                            tracing::error!("stt: rollback failed: {}", rollback_err);
+                                        }
+                                    }
+
+                                    let _ = bus.broadcast(Event::Speech(SpeechEvent::SttBackendSwitchFailed {
+                                        backend: backend.clone(),
+                                        reason: e.to_string(),
+                                    })).await;
+                                }
+                            }
+
+                            // Clear switching flag to resume audio processing
+                            self.backend_switching = false;
+                        }
                         Ok(_) => {}
                         Err(broadcast::error::RecvError::Lagged(_)) => continue,
                         Err(broadcast::error::RecvError::Closed) => {
@@ -948,10 +1052,12 @@ impl Actor for SttActor {
                         std::future::pending().await
                     }
                 } => {
-                    // Skip always-on processing while listen mode is active or speech loop is disabled.
-                    // Listen mode dispatches its own audio via listen_audio_rx.
+                    // Skip always-on processing while listen mode is active, speech loop is disabled,
+                    // or backend switch is in progress.
                     if let Some(buffer) = audio_buffer {
-                        if !self.listen_mode_active && self.speech_loop_enabled {
+                        if self.backend_switching {
+                            tracing::debug!("skipping audio during backend switch");
+                        } else if !self.listen_mode_active && self.speech_loop_enabled {
                             self.handle_audio_buffer(buffer, &bus).await;
                         }
                     }
@@ -964,8 +1070,13 @@ impl Actor for SttActor {
                     }
                 } => {
                     // Listen mode is independent of speech_loop_enabled (explicit user request)
+                    // but is paused during backend switch.
                     if let (Some(buffer), Some(session_id)) = (listen_buffer, self.listen_session_id) {
-                        self.handle_listen_audio_buffer(buffer, session_id, &bus).await;
+                        if self.backend_switching {
+                            tracing::debug!("skipping listen audio during backend switch");
+                        } else {
+                            self.handle_listen_audio_buffer(buffer, session_id, &bus).await;
+                        }
                     }
                 }
             }

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -18,6 +18,15 @@ const DEFAULT_BUFFER_DURATION_SECS: f32 = 3.0;
 /// Audio chunk duration for Whisper fake-streaming /listen sessions (1s for responsiveness).
 const LISTEN_WHISPER_BUFFER_DURATION_SECS: f32 = 1.0;
 
+/// Audio chunk duration for sherpa-onnx Zipformer listen sessions (200ms for responsiveness).
+const LISTEN_SHERPA_BUFFER_DURATION_SECS: f32 = 0.2;
+
+/// How often to run sherpa decode on the growing listen buffer.
+const LISTEN_SHERPA_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Maximum audio retained for sherpa growing-window decode (8s at 16kHz).
+const LISTEN_SHERPA_MAX_SAMPLES: usize = 16_000 * 8;
+
 /// Maximum rolling audio retained for listen-mode interim transcriptions (6 seconds at 16kHz).
 const LISTEN_ROLLING_MAX_SAMPLES: usize = 16_000 * 3;
 
@@ -69,6 +78,12 @@ pub struct SttActor {
     listen_rolling_samples: Vec<f32>,
     /// Time of last interim Whisper transcription in listen mode.
     listen_last_interim: Option<std::time::Instant>,
+    /// Sender to the sherpa worker thread. Some when sherpa is active for listen mode.
+    sherpa_worker_tx: Option<std::sync::mpsc::Sender<SherpaCmd>>,
+    /// True while sherpa is the active STT for the current listen session.
+    sherpa_listen_active: bool,
+    /// Time of last sherpa decode in the current listen session.
+    listen_last_sherpa: Option<std::time::Instant>,
 }
 
 impl SttActor {
@@ -109,6 +124,9 @@ impl SttActor {
             speech_loop_enabled: true,
             listen_rolling_samples: Vec::new(),
             listen_last_interim: None,
+            sherpa_worker_tx: None,
+            sherpa_listen_active: false,
+            listen_last_sherpa: None,
         }
     }
 
@@ -141,6 +159,48 @@ impl SttActor {
     pub fn with_confidence_threshold(mut self, threshold: f32) -> Self {
         self.confidence_threshold = threshold.clamp(0.0, 1.0);
         self
+    }
+
+    async fn init_sherpa_backend(
+        &self,
+        model_dir: &std::path::Path,
+    ) -> Option<std::sync::mpsc::Sender<SherpaCmd>> {
+        let encoder = model_dir
+            .join("sherpa_encoder.onnx")
+            .to_string_lossy()
+            .into_owned();
+        let decoder = model_dir
+            .join("sherpa_decoder.onnx")
+            .to_string_lossy()
+            .into_owned();
+        let joiner = model_dir
+            .join("sherpa_joiner.onnx")
+            .to_string_lossy()
+            .into_owned();
+        let tokens = model_dir
+            .join("sherpa_tokens.txt")
+            .to_string_lossy()
+            .into_owned();
+
+        match tokio::task::spawn_blocking(move || {
+            crate::sherpa_stt::SherpaZipformerStt::load(&encoder, &decoder, &joiner, &tokens)
+        })
+        .await
+        {
+            Ok(Ok(model)) => {
+                let (tx, rx) = std::sync::mpsc::channel::<SherpaCmd>();
+                std::thread::spawn(move || sherpa_worker_loop(model, rx));
+                Some(tx)
+            }
+            Ok(Err(e)) => {
+                tracing::warn!("listen: sherpa init failed, falling back to whisper: {}", e);
+                None
+            }
+            Err(e) => {
+                tracing::warn!("listen: sherpa spawn_blocking panicked: {}", e);
+                None
+            }
+        }
     }
 
     fn next_request_id(&mut self) -> u64 {
@@ -288,80 +348,160 @@ impl SttActor {
 
     /// Handle an audio buffer for continuous listen mode.
     ///
-    /// Implements Whisper fake-streaming via a sliding window:
-    /// - Every 1.5s, runs Whisper on the accumulated rolling audio → emits `is_final=false`
-    /// - When VAD detects end-of-speech, runs Whisper once more → emits `is_final=true`
+    /// Sherpa primary path: growing-window decode every 200ms — returns text every ~200ms.
+    /// Whisper fallback: rolling buffer + interim every 1500ms (original fake-streaming).
     async fn handle_listen_audio_buffer(
         &mut self,
         buffer: AudioBuffer,
         session_id: u64,
         bus: &Arc<EventBus>,
     ) {
-        // Accumulate samples in rolling buffer (max 6s at 16kHz).
-        self.listen_rolling_samples
-            .extend_from_slice(&buffer.samples);
-        if self.listen_rolling_samples.len() > LISTEN_ROLLING_MAX_SAMPLES {
-            let excess = self.listen_rolling_samples.len() - LISTEN_ROLLING_MAX_SAMPLES;
-            self.listen_rolling_samples.drain(..excess);
-        }
-
-        // Emit interim (non-final) transcription every LISTEN_INTERIM_INTERVAL
-        // once at least 2s of audio has accumulated AND audio is not silent.
-        let enough_audio = self.listen_rolling_samples.len() >= LISTEN_INTERIM_MIN_SAMPLES;
-        let interval_elapsed = self
-            .listen_last_interim
-            .map(|t| t.elapsed() >= LISTEN_INTERIM_INTERVAL)
-            .unwrap_or(true);
-        // Gate: skip if rolling buffer is mostly silence (avoids Whisper hallucinations).
-        let rolling_rms = crate::silence_detector::calculate_rms(&self.listen_rolling_samples);
-        let has_speech = rolling_rms > self.stt_energy_threshold;
-
-        if enough_audio && interval_elapsed && has_speech {
-            let interim_buf = AudioBuffer {
-                samples: self.listen_rolling_samples.clone(),
-                sample_rate: buffer.sample_rate,
-                channels: buffer.channels,
-            };
-            self.listen_last_interim = Some(std::time::Instant::now());
-            match tokio::time::timeout(TRANSCRIPTION_TIMEOUT, self.transcribe(interim_buf)).await {
-                Ok(Ok(result)) if !result.text.trim().is_empty() => {
-                    let _ = bus
-                        .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
-                            text: result.text,
-                            is_final: false,
-                            confidence: result.confidence,
-                            session_id,
-                        }))
-                        .await;
-                }
-                Ok(Ok(_)) => {}
-                Ok(Err(e)) => tracing::warn!("listen[interim]: error: {}", e),
-                Err(_) => tracing::warn!("listen[interim]: timeout"),
+        if self.sherpa_listen_active {
+            // ── Sherpa path ──────────────────────────────────────────────────────────
+            // Grow the rolling buffer (cap at 8s).
+            self.listen_rolling_samples
+                .extend_from_slice(&buffer.samples);
+            if self.listen_rolling_samples.len() > LISTEN_SHERPA_MAX_SAMPLES {
+                let excess = self.listen_rolling_samples.len() - LISTEN_SHERPA_MAX_SAMPLES;
+                self.listen_rolling_samples.drain(..excess);
             }
-        }
 
-        // VAD for final speech-end detection.
-        if let Some(ready_buffer) = self
-            .listen_mode_vad
-            .feed(&buffer.samples, buffer.sample_rate, buffer.channels)
-        {
-            match tokio::time::timeout(TRANSCRIPTION_TIMEOUT, self.transcribe(ready_buffer)).await {
-                Ok(Ok(result)) if !result.text.trim().is_empty() => {
-                    let _ = bus
-                        .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
-                            text: result.text,
-                            is_final: true,
-                            confidence: result.confidence,
-                            session_id,
-                        }))
-                        .await;
-                    // Reset rolling state for next utterance.
-                    self.listen_rolling_samples.clear();
-                    self.listen_last_interim = None;
+            let interval_elapsed = self
+                .listen_last_sherpa
+                .map(|t| t.elapsed() >= LISTEN_SHERPA_INTERVAL)
+                .unwrap_or(true);
+
+            if interval_elapsed && !self.listen_rolling_samples.is_empty() {
+                if let Some(tx) = &self.sherpa_worker_tx {
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    let samples = self.listen_rolling_samples.clone();
+                    let _ = tx.send(SherpaCmd::Decode {
+                        samples,
+                        reply: reply_tx,
+                    });
+                    self.listen_last_sherpa = Some(std::time::Instant::now());
+
+                    match tokio::time::timeout(Duration::from_millis(500), reply_rx).await {
+                        Ok(Ok(text)) if !text.trim().is_empty() => {
+                            let _ = bus
+                                .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                                    text: text.trim().to_string(),
+                                    is_final: false,
+                                    confidence: 0.9,
+                                    session_id,
+                                }))
+                                .await;
+                        }
+                        Ok(Ok(_)) => {}
+                        Ok(Err(_)) => tracing::warn!("listen[sherpa]: worker channel closed"),
+                        Err(_) => tracing::warn!("listen[sherpa]: decode timeout"),
+                    }
                 }
-                Ok(Ok(_)) => {}
-                Ok(Err(e)) => tracing::warn!("listen[whisper]: transcription error: {}", e),
-                Err(_) => tracing::warn!("listen[whisper]: transcription timeout"),
+            }
+
+            // VAD for final speech-end detection.
+            if let Some(_ready_buffer) =
+                self.listen_mode_vad
+                    .feed(&buffer.samples, buffer.sample_rate, buffer.channels)
+            {
+                // Emit final transcription of the accumulated rolling buffer.
+                if let Some(tx) = &self.sherpa_worker_tx {
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    let samples = self.listen_rolling_samples.clone();
+                    let _ = tx.send(SherpaCmd::Decode {
+                        samples,
+                        reply: reply_tx,
+                    });
+
+                    match tokio::time::timeout(Duration::from_millis(1000), reply_rx).await {
+                        Ok(Ok(text)) if !text.trim().is_empty() => {
+                            let _ = bus
+                                .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                                    text: text.trim().to_string(),
+                                    is_final: true,
+                                    confidence: 0.9,
+                                    session_id,
+                                }))
+                                .await;
+                        }
+                        Ok(Ok(_)) => {}
+                        Ok(Err(_)) => tracing::warn!("listen[sherpa]: worker closed on final"),
+                        Err(_) => tracing::warn!("listen[sherpa]: final decode timeout"),
+                    }
+                }
+                // Reset rolling buffer for next utterance.
+                self.listen_rolling_samples.clear();
+                self.listen_last_sherpa = None;
+            }
+        } else {
+            // ── Whisper fallback path ─────────────────────────────────────────────────
+            // Accumulate samples in rolling buffer (max 3s at 16kHz).
+            self.listen_rolling_samples
+                .extend_from_slice(&buffer.samples);
+            if self.listen_rolling_samples.len() > LISTEN_ROLLING_MAX_SAMPLES {
+                let excess = self.listen_rolling_samples.len() - LISTEN_ROLLING_MAX_SAMPLES;
+                self.listen_rolling_samples.drain(..excess);
+            }
+
+            // Emit interim transcription every LISTEN_INTERIM_INTERVAL once we have enough audio.
+            let enough_audio = self.listen_rolling_samples.len() >= LISTEN_INTERIM_MIN_SAMPLES;
+            let interval_elapsed = self
+                .listen_last_interim
+                .map(|t| t.elapsed() >= LISTEN_INTERIM_INTERVAL)
+                .unwrap_or(true);
+            let rolling_rms = crate::silence_detector::calculate_rms(&self.listen_rolling_samples);
+            let has_speech = rolling_rms > self.stt_energy_threshold;
+
+            if enough_audio && interval_elapsed && has_speech {
+                let interim_buf = AudioBuffer {
+                    samples: self.listen_rolling_samples.clone(),
+                    sample_rate: buffer.sample_rate,
+                    channels: buffer.channels,
+                };
+                self.listen_last_interim = Some(std::time::Instant::now());
+                match tokio::time::timeout(TRANSCRIPTION_TIMEOUT, self.transcribe(interim_buf))
+                    .await
+                {
+                    Ok(Ok(result)) if !result.text.trim().is_empty() => {
+                        let _ = bus
+                            .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                                text: result.text,
+                                is_final: false,
+                                confidence: result.confidence,
+                                session_id,
+                            }))
+                            .await;
+                    }
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => tracing::warn!("listen[whisper/interim]: error: {}", e),
+                    Err(_) => tracing::warn!("listen[whisper/interim]: timeout"),
+                }
+            }
+
+            // VAD for final speech-end detection.
+            if let Some(ready_buffer) =
+                self.listen_mode_vad
+                    .feed(&buffer.samples, buffer.sample_rate, buffer.channels)
+            {
+                match tokio::time::timeout(TRANSCRIPTION_TIMEOUT, self.transcribe(ready_buffer))
+                    .await
+                {
+                    Ok(Ok(result)) if !result.text.trim().is_empty() => {
+                        let _ = bus
+                            .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                                text: result.text,
+                                is_final: true,
+                                confidence: result.confidence,
+                                session_id,
+                            }))
+                            .await;
+                        self.listen_rolling_samples.clear();
+                        self.listen_last_interim = None;
+                    }
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => tracing::warn!("listen[whisper]: transcription error: {}", e),
+                    Err(_) => tracing::warn!("listen[whisper]: transcription timeout"),
+                }
             }
         }
     }
@@ -492,15 +632,44 @@ impl Actor for SttActor {
                         }
                         Ok(Event::Speech(SpeechEvent::ListenModeRequested { session_id })) => {
                             if self.listen_session_id.is_some() {
-                                tracing::warn!("listen: new session {} requested while session {:?} active - stopping old session first", session_id, self.listen_session_id);
+                                tracing::warn!(
+                                    "listen: new session {} requested while session {:?} active - stopping old session first",
+                                    session_id,
+                                    self.listen_session_id
+                                );
+                                // Shut down the previous sherpa worker if any.
+                                if let Some(old_tx) = self.sherpa_worker_tx.take() {
+                                    let _ = old_tx.send(SherpaCmd::Shutdown);
+                                }
+                                self.sherpa_listen_active = false;
                                 self.listen_audio_rx = None;
                                 self.listen_audio_stream = None;
                             }
+
+                            // Try to initialise sherpa if models are present.
+                            let sherpa_worker = if let Some(ref dir) = self.model_dir.clone() {
+                                if crate::sherpa_stt::SherpaZipformerStt::models_present(dir) {
+                                    self.init_sherpa_backend(dir).await
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            };
+
+                            let (buffer_duration, backend_label) = if sherpa_worker.is_some() {
+                                (LISTEN_SHERPA_BUFFER_DURATION_SECS, "sherpa-onnx")
+                            } else {
+                                (LISTEN_WHISPER_BUFFER_DURATION_SECS, "whisper fake-streaming")
+                            };
+
+                            self.sherpa_worker_tx = sherpa_worker;
+                            self.sherpa_listen_active = self.sherpa_worker_tx.is_some();
+                            self.listen_last_sherpa = None;
+
                             let config = AudioInputConfig {
                                 sample_rate: 16_000,
-                                buffer_duration_secs: LISTEN_WHISPER_BUFFER_DURATION_SECS,
-                                // Pass all audio to SilenceDetector - it handles
-                                // voice/silence classification internally.
+                                buffer_duration_secs: buffer_duration,
                                 energy_threshold: 0.0,
                                 device_name: self.microphone_device.clone(),
                             };
@@ -509,19 +678,20 @@ impl Actor for SttActor {
                                     self.listen_session_id = Some(session_id);
                                     self.listen_audio_stream = Some(stream);
                                     self.listen_audio_rx = Some(rx);
-                                    // Suppress always-on STT while listen mode is active to
-                                    // prevent conflicting TranscriptionCompleted events and
-                                    // unintended inference calls.
                                     self.listen_mode_active = true;
                                     self.always_listening_vad.reset();
-                                    // Reset listen mode VAD and rolling buffer for a clean session.
                                     self.listen_mode_vad.reset();
                                     self.listen_rolling_samples.clear();
                                     self.listen_last_interim = None;
-                                    tracing::info!("listen: session {} started (whisper fake-streaming)", session_id);
+                                    tracing::info!("listen: session {} started ({})", session_id, backend_label);
                                 }
                                 Err(e) => {
                                     tracing::error!("listen: failed to start audio capture: {}", e);
+                                    // Clean up sherpa worker if audio failed.
+                                    if let Some(tx) = self.sherpa_worker_tx.take() {
+                                        let _ = tx.send(SherpaCmd::Shutdown);
+                                    }
+                                    self.sherpa_listen_active = false;
                                     let _ = bus
                                         .broadcast(Event::Speech(SpeechEvent::ListenModeStopped {
                                             session_id,
@@ -532,6 +702,12 @@ impl Actor for SttActor {
                         }
                         Ok(Event::Speech(SpeechEvent::ListenModeStopRequested { session_id })) => {
                             if self.listen_session_id == Some(session_id) {
+                                // Shut down sherpa worker if active.
+                                if let Some(tx) = self.sherpa_worker_tx.take() {
+                                    let _ = tx.send(SherpaCmd::Shutdown);
+                                }
+                                self.sherpa_listen_active = false;
+                                self.listen_last_sherpa = None;
                                 self.listen_session_id = None;
                                 self.listen_audio_rx = None;
                                 self.listen_audio_stream = None;
@@ -588,6 +764,10 @@ impl Actor for SttActor {
     }
 
     async fn stop(&mut self) -> Result<(), ActorError> {
+        // Shut down sherpa worker if running.
+        if let Some(tx) = self.sherpa_worker_tx.take() {
+            let _ = tx.send(SherpaCmd::Shutdown);
+        }
         self.audio_rx = None;
         self.audio_stream = None;
         self.listen_audio_rx = None;
@@ -634,6 +814,31 @@ fn candle_worker_loop(
                     TranscriptionResult { text, confidence }
                 });
                 let _ = reply.send(result);
+            }
+        }
+    }
+}
+
+/// Commands for the sherpa-onnx worker thread.
+enum SherpaCmd {
+    Decode {
+        samples: Vec<f32>,
+        reply: oneshot::Sender<String>,
+    },
+    Shutdown,
+}
+
+/// Worker loop for blocking sherpa-onnx decode calls.
+fn sherpa_worker_loop(
+    mut model: crate::sherpa_stt::SherpaZipformerStt,
+    rx: std::sync::mpsc::Receiver<SherpaCmd>,
+) {
+    while let Ok(cmd) = rx.recv() {
+        match cmd {
+            SherpaCmd::Shutdown => break,
+            SherpaCmd::Decode { samples, reply } => {
+                let text = model.decode_chunk(samples);
+                let _ = reply.send(text);
             }
         }
     }

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -702,6 +702,14 @@ impl SttActor {
             }
         } else {
             // ── Whisper fallback path ─────────────────────────────────────────────────
+            // Log a warning if the Parakeet backend is active but its worker isn't set —
+            // this means the backend handle wasn't cloned correctly in ListenModeRequested.
+            if self.backend == SttBackend::Parakeet {
+                tracing::warn!(
+                    "listen[fallback]: Parakeet backend is active but parakeet_listen_active=false; \
+                     falling back to Whisper path — check if Parakeet models are downloaded"
+                );
+            }
             // Accumulate samples in rolling buffer (max 3s at 16kHz).
             self.listen_rolling_samples
                 .extend_from_slice(&buffer.samples);

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -27,6 +27,13 @@ const LISTEN_SHERPA_INTERVAL: Duration = Duration::from_millis(200);
 /// Maximum audio retained for sherpa growing-window decode (8s at 16kHz).
 const LISTEN_SHERPA_MAX_SAMPLES: usize = 16_000 * 8;
 
+/// Audio chunk duration for Parakeet-EOU streaming sessions (160ms — required chunk size).
+const LISTEN_PARAKEET_BUFFER_DURATION_SECS: f32 = 0.16;
+
+/// Exact chunk size required by ParakeetEOU.transcribe() — 160ms at 16kHz.
+/// Feeding larger chunks causes the model to silently discard all but the last 160ms.
+const PARAKEET_CHUNK_SAMPLES: usize = 2_560;
+
 /// Maximum rolling audio retained for listen-mode interim transcriptions (6 seconds at 16kHz).
 const LISTEN_ROLLING_MAX_SAMPLES: usize = 16_000 * 3;
 
@@ -84,6 +91,12 @@ pub struct SttActor {
     sherpa_listen_active: bool,
     /// Time of last sherpa decode in the current listen session.
     listen_last_sherpa: Option<std::time::Instant>,
+    /// Sender to the parakeet worker thread. Some when parakeet is active for listen mode.
+    parakeet_worker_tx: Option<std::sync::mpsc::Sender<ParakeetCommand>>,
+    /// True while parakeet is the active STT for the current listen session.
+    parakeet_listen_active: bool,
+    /// Accumulator for sub-chunk parakeet audio. Drained in 2560-sample (160ms) chunks.
+    parakeet_chunk_accumulator: Vec<f32>,
     /// True while a backend switch is in progress. Suppresses audio processing.
     backend_switching: bool,
 }
@@ -129,6 +142,9 @@ impl SttActor {
             sherpa_worker_tx: None,
             sherpa_listen_active: false,
             listen_last_sherpa: None,
+            parakeet_worker_tx: None,
+            parakeet_listen_active: false,
+            parakeet_chunk_accumulator: Vec::new(),
             backend_switching: false,
         }
     }
@@ -608,6 +624,82 @@ impl SttActor {
                 self.listen_rolling_samples.clear();
                 self.listen_last_sherpa = None;
             }
+        } else if self.parakeet_listen_active {
+            // ── Parakeet streaming path ───────────────────────────────────────────────
+            // Accumulate incoming audio into the chunk buffer.
+            self.parakeet_chunk_accumulator
+                .extend_from_slice(&buffer.samples);
+
+            // Drain 2560-sample (160ms) chunks and decode each one.
+            while self.parakeet_chunk_accumulator.len() >= PARAKEET_CHUNK_SAMPLES {
+                let chunk: Vec<f32> = self
+                    .parakeet_chunk_accumulator
+                    .drain(..PARAKEET_CHUNK_SAMPLES)
+                    .collect();
+
+                if let Some(tx) = &self.parakeet_worker_tx {
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    let _ = tx.send(ParakeetCommand::Chunk {
+                        samples: chunk,
+                        reply: reply_tx,
+                    });
+                    match tokio::time::timeout(Duration::from_millis(500), reply_rx).await {
+                        Ok(Ok(text)) if !text.trim().is_empty() => {
+                            let _ = bus
+                                .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                                    text: text.trim().to_string(),
+                                    is_final: false,
+                                    confidence: 0.85,
+                                    session_id,
+                                }))
+                                .await;
+                        }
+                        Ok(Ok(_)) => {}
+                        Ok(Err(_)) => tracing::warn!("listen[parakeet]: worker channel closed"),
+                        Err(_) => tracing::warn!("listen[parakeet]: chunk decode timeout"),
+                    }
+                }
+            }
+
+            // VAD for final speech-end detection.
+            if let Some(_ready_buffer) =
+                self.listen_mode_vad
+                    .feed(&buffer.samples, buffer.sample_rate, buffer.channels)
+            {
+                // Flush any remaining sub-chunk samples (pad to 2560 with silence).
+                if !self.parakeet_chunk_accumulator.is_empty() {
+                    let mut remaining = self.parakeet_chunk_accumulator.clone();
+                    remaining.resize(PARAKEET_CHUNK_SAMPLES, 0.0_f32);
+
+                    if let Some(tx) = &self.parakeet_worker_tx {
+                        let (reply_tx, reply_rx) = oneshot::channel();
+                        let _ = tx.send(ParakeetCommand::Chunk {
+                            samples: remaining,
+                            reply: reply_tx,
+                        });
+                        match tokio::time::timeout(Duration::from_millis(800), reply_rx).await {
+                            Ok(Ok(text)) if !text.trim().is_empty() => {
+                                let _ = bus
+                                    .broadcast(Event::Speech(
+                                        SpeechEvent::ListenModeTranscription {
+                                            text: text.trim().to_string(),
+                                            is_final: true,
+                                            confidence: 0.85,
+                                            session_id,
+                                        },
+                                    ))
+                                    .await;
+                            }
+                            Ok(Ok(_)) => {}
+                            Ok(Err(_)) => {
+                                tracing::warn!("listen[parakeet]: worker closed on flush")
+                            }
+                            Err(_) => tracing::warn!("listen[parakeet]: flush timeout"),
+                        }
+                    }
+                    self.parakeet_chunk_accumulator.clear();
+                }
+            }
         } else {
             // ── Whisper fallback path ─────────────────────────────────────────────────
             // Accumulate samples in rolling buffer (max 3s at 16kHz).
@@ -852,6 +944,12 @@ impl Actor for SttActor {
                                     let _ = old_tx.send(SherpaCmd::Shutdown);
                                 }
                                 self.sherpa_listen_active = false;
+                                // Shut down the previous parakeet worker if any.
+                                if let Some(old_tx) = self.parakeet_worker_tx.take() {
+                                    let _ = old_tx.send(ParakeetCommand::Shutdown);
+                                }
+                                self.parakeet_listen_active = false;
+                                self.parakeet_chunk_accumulator.clear();
                                 self.listen_audio_rx = None;
                                 self.listen_audio_stream = None;
                             }
@@ -866,8 +964,18 @@ impl Actor for SttActor {
                                 _ => None,
                             };
 
+                            // Use Parakeet for listen-mode streaming when Parakeet is active.
+                            let parakeet_worker = match (&self.backend, &self.backend_handle) {
+                                (SttBackend::Parakeet, Some(SttBackendHandle::Parakeet { tx })) => {
+                                    Some(tx.clone())
+                                }
+                                _ => None,
+                            };
+
                             let (buffer_duration, backend_label) = if sherpa_worker.is_some() {
                                 (LISTEN_SHERPA_BUFFER_DURATION_SECS, "sherpa-onnx")
+                            } else if parakeet_worker.is_some() {
+                                (LISTEN_PARAKEET_BUFFER_DURATION_SECS, "parakeet streaming")
                             } else {
                                 (LISTEN_WHISPER_BUFFER_DURATION_SECS, "whisper fake-streaming")
                             };
@@ -875,6 +983,9 @@ impl Actor for SttActor {
                             self.sherpa_worker_tx = sherpa_worker;
                             self.sherpa_listen_active = self.sherpa_worker_tx.is_some();
                             self.listen_last_sherpa = None;
+                            self.parakeet_worker_tx = parakeet_worker;
+                            self.parakeet_listen_active = self.parakeet_worker_tx.is_some();
+                            self.parakeet_chunk_accumulator.clear();
 
                             let config = AudioInputConfig {
                                 sample_rate: 16_000,
@@ -901,6 +1012,12 @@ impl Actor for SttActor {
                                         let _ = tx.send(SherpaCmd::Shutdown);
                                     }
                                     self.sherpa_listen_active = false;
+                                    // Clean up parakeet worker if audio failed.
+                                    if let Some(tx) = self.parakeet_worker_tx.take() {
+                                        let _ = tx.send(ParakeetCommand::Shutdown);
+                                    }
+                                    self.parakeet_listen_active = false;
+                                    self.parakeet_chunk_accumulator.clear();
                                     let _ = bus
                                         .broadcast(Event::Speech(SpeechEvent::ListenModeStopped {
                                             session_id,
@@ -917,6 +1034,12 @@ impl Actor for SttActor {
                                 }
                                 self.sherpa_listen_active = false;
                                 self.listen_last_sherpa = None;
+                                // Shut down parakeet worker if active.
+                                if let Some(tx) = self.parakeet_worker_tx.take() {
+                                    let _ = tx.send(ParakeetCommand::Shutdown);
+                                }
+                                self.parakeet_listen_active = false;
+                                self.parakeet_chunk_accumulator.clear();
                                 self.listen_session_id = None;
                                 self.listen_audio_rx = None;
                                 self.listen_audio_stream = None;
@@ -1050,6 +1173,12 @@ impl Actor for SttActor {
         if let Some(tx) = self.sherpa_worker_tx.take() {
             let _ = tx.send(SherpaCmd::Shutdown);
         }
+        // Shut down parakeet worker if running.
+        if let Some(tx) = self.parakeet_worker_tx.take() {
+            let _ = tx.send(ParakeetCommand::Shutdown);
+        }
+        self.parakeet_listen_active = false;
+        self.parakeet_chunk_accumulator.clear();
         self.audio_rx = None;
         self.audio_stream = None;
         self.listen_audio_rx = None;
@@ -1149,6 +1278,12 @@ enum ParakeetCommand {
         samples: Vec<i16>,
         reply: oneshot::Sender<Result<TranscriptionResult, SpeechError>>,
     },
+    /// Streaming 160ms chunk for /listen mode.
+    /// Uses f32 directly — no lossy i16 round-trip.
+    Chunk {
+        samples: Vec<f32>,
+        reply: oneshot::Sender<String>,
+    },
     Shutdown,
 }
 
@@ -1160,6 +1295,12 @@ fn parakeet_worker_loop(
     while let Ok(command) = rx.recv() {
         match command {
             ParakeetCommand::Shutdown => break,
+            ParakeetCommand::Chunk { samples, reply } => {
+                let text = model
+                    .decode_chunk_f32(&samples)
+                    .unwrap_or_default();
+                let _ = reply.send(text);
+            }
             ParakeetCommand::Transcribe { samples, reply } => {
                 let result = model.decode_chunk(&samples).map(|text| {
                     let confidence = if text.trim().is_empty() {

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -306,25 +306,25 @@ impl SttActor {
 
         // Build model file paths
         let encoder = sherpa_model_dir
-            .join("sherpa_encoder.onnx")
+            .join("encoder-epoch-99-avg-1.int8.onnx")
             .to_str()
             .ok_or_else(|| SpeechError::SttInitFailed("non-UTF-8 path for encoder".to_string()))?
             .to_string();
 
         let decoder = sherpa_model_dir
-            .join("sherpa_decoder.onnx")
+            .join("decoder-epoch-99-avg-1.int8.onnx")
             .to_str()
             .ok_or_else(|| SpeechError::SttInitFailed("non-UTF-8 path for decoder".to_string()))?
             .to_string();
 
         let joiner = sherpa_model_dir
-            .join("sherpa_joiner.onnx")
+            .join("joiner-epoch-99-avg-1.int8.onnx")
             .to_str()
             .ok_or_else(|| SpeechError::SttInitFailed("non-UTF-8 path for joiner".to_string()))?
             .to_string();
 
         let tokens = sherpa_model_dir
-            .join("sherpa_tokens.txt")
+            .join("tokens.txt")
             .to_str()
             .ok_or_else(|| SpeechError::SttInitFailed("non-UTF-8 path for tokens".to_string()))?
             .to_string();

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -214,7 +214,7 @@ impl SttActor {
             SttBackend::Mock => SttBackendHandle::Mock,
             SttBackend::Whisper => self.initialize_candle_backend().await?,
             SttBackend::Sherpa => SttBackendHandle::Sherpa,
-            SttBackend::Parakeet => SttBackendHandle::Parakeet,
+            SttBackend::Parakeet => self.initialize_parakeet_backend().await?,
         };
 
         self.backend_handle = Some(handle);
@@ -241,6 +241,36 @@ impl SttActor {
         });
 
         Ok(SttBackendHandle::CandleWhisper { tx: cmd_tx })
+    }
+
+    async fn initialize_parakeet_backend(&self) -> Result<SttBackendHandle, SpeechError> {
+        let model_dir = self
+            .model_dir
+            .clone()
+            .ok_or_else(|| SpeechError::SttInitFailed("model_dir not configured".to_string()))?;
+
+        let parakeet_model_dir = model_dir.join("parakeet");
+
+        tracing::info!(
+            "initializing Parakeet backend from {}",
+            parakeet_model_dir.display()
+        );
+
+        // Load model in spawn_blocking to avoid blocking async
+        let model = tokio::task::spawn_blocking(move || {
+            crate::parakeet_stt::ParakeetStt::load(&parakeet_model_dir)
+        })
+        .await
+        .map_err(|e| SpeechError::SttInitFailed(format!("spawn_blocking panicked: {}", e)))??;
+
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<ParakeetCommand>();
+        std::thread::spawn(move || {
+            parakeet_worker_loop(model, cmd_rx);
+        });
+
+        tracing::info!("Parakeet backend initialized successfully");
+
+        Ok(SttBackendHandle::Parakeet { tx: cmd_tx })
     }
 
     fn maybe_start_audio_capture(&mut self) -> Result<(), SpeechError> {
@@ -300,9 +330,30 @@ impl SttActor {
             Some(SttBackendHandle::Sherpa) => Err(SpeechError::TranscriptionFailed(
                 "Sherpa backend not yet implemented".to_string(),
             )),
-            Some(SttBackendHandle::Parakeet) => Err(SpeechError::TranscriptionFailed(
-                "Parakeet backend not yet implemented".to_string(),
-            )),
+            Some(SttBackendHandle::Parakeet { tx }) => {
+                // Convert f32 samples to i16 for parakeet
+                let samples_i16: Vec<i16> = buffer
+                    .samples
+                    .iter()
+                    .map(|&s| (s * 32768.0).clamp(-32768.0, 32767.0) as i16)
+                    .collect();
+
+                let (reply_tx, reply_rx) = oneshot::channel();
+                tx.send(ParakeetCommand::Transcribe {
+                    samples: samples_i16,
+                    reply: reply_tx,
+                })
+                .map_err(|e| {
+                    SpeechError::TranscriptionFailed(format!(
+                        "parakeet worker channel send failed: {}",
+                        e
+                    ))
+                })?;
+
+                reply_rx.await.map_err(|e| {
+                    SpeechError::TranscriptionFailed(format!("parakeet worker reply failed: {}", e))
+                })?
+            }
             None => Err(SpeechError::TranscriptionFailed(
                 "STT backend not initialized".to_string(),
             )),
@@ -782,8 +833,14 @@ impl Actor for SttActor {
         self.listen_audio_stream = None;
         self.listen_session_id = None;
 
-        if let Some(SttBackendHandle::CandleWhisper { tx }) = self.backend_handle.take() {
-            let _ = tx.send(WorkerCommand::Shutdown);
+        match self.backend_handle.take() {
+            Some(SttBackendHandle::CandleWhisper { tx }) => {
+                let _ = tx.send(WorkerCommand::Shutdown);
+            }
+            Some(SttBackendHandle::Parakeet { tx }) => {
+                let _ = tx.send(ParakeetCommand::Shutdown);
+            }
+            _ => {}
         }
 
         Ok(())
@@ -797,8 +854,10 @@ enum SttBackendHandle {
     },
     /// Sherpa backend placeholder (implementation in Unit 3).
     Sherpa,
-    /// Parakeet backend placeholder (implementation in Unit 4).
-    Parakeet,
+    /// Parakeet backend — NVIDIA Parakeet-EOU ONNX streaming STT.
+    Parakeet {
+        tx: std::sync::mpsc::Sender<ParakeetCommand>,
+    },
 }
 
 enum WorkerCommand {
@@ -851,6 +910,42 @@ fn sherpa_worker_loop(
             SherpaCmd::Decode { samples, reply } => {
                 let text = model.decode_chunk(samples);
                 let _ = reply.send(text);
+            }
+        }
+    }
+}
+
+/// Commands for the Parakeet worker thread.
+enum ParakeetCommand {
+    Transcribe {
+        samples: Vec<i16>,
+        reply: oneshot::Sender<Result<TranscriptionResult, SpeechError>>,
+    },
+    Shutdown,
+}
+
+/// Worker loop for blocking Parakeet decode calls.
+fn parakeet_worker_loop(
+    mut model: crate::parakeet_stt::ParakeetStt,
+    rx: std::sync::mpsc::Receiver<ParakeetCommand>,
+) {
+    while let Ok(command) = rx.recv() {
+        match command {
+            ParakeetCommand::Shutdown => break,
+            ParakeetCommand::Transcribe { samples, reply } => {
+                let result = model.decode_chunk(&samples).map(|text| {
+                    let confidence = if text.trim().is_empty() {
+                        0.0
+                    } else {
+                        // Calculate confidence from audio energy (similar to Whisper)
+                        let samples_f32: Vec<f32> =
+                            samples.iter().map(|&s| s as f32 / 32768.0).collect();
+                        (crate::silence_detector::calculate_rms(&samples_f32) * 10.0)
+                            .clamp(0.55, 0.99)
+                    };
+                    TranscriptionResult { text, confidence }
+                });
+                let _ = reply.send(result);
             }
         }
     }

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -97,6 +97,10 @@ pub struct SttActor {
     parakeet_listen_active: bool,
     /// Accumulator for sub-chunk parakeet audio. Drained in 2560-sample (160ms) chunks.
     parakeet_chunk_accumulator: Vec<f32>,
+    /// Token text accumulated for the current Parakeet listen utterance.
+    /// Parakeet-EOU emits SentencePiece tokens (e.g. `_hello`) per 160ms chunk;
+    /// this accumulates them into a full sentence for display.
+    parakeet_session_text: String,
     /// True while a backend switch is in progress. Suppresses audio processing.
     backend_switching: bool,
 }
@@ -145,6 +149,7 @@ impl SttActor {
             parakeet_worker_tx: None,
             parakeet_listen_active: false,
             parakeet_chunk_accumulator: Vec::new(),
+            parakeet_session_text: String::new(),
             backend_switching: false,
         }
     }
@@ -644,15 +649,20 @@ impl SttActor {
                         reply: reply_tx,
                     });
                     match tokio::time::timeout(Duration::from_millis(500), reply_rx).await {
-                        Ok(Ok(text)) if !text.trim().is_empty() => {
-                            let _ = bus
-                                .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
-                                    text: text.trim().to_string(),
-                                    is_final: false,
-                                    confidence: 0.85,
-                                    session_id,
-                                }))
-                                .await;
+                        Ok(Ok(token)) if !token.trim().is_empty() => {
+                            // Accumulate SentencePiece tokens (e.g. "_hello", "_world").
+                            self.parakeet_session_text.push_str(&token);
+                            let display = Self::decode_parakeet_tokens(&self.parakeet_session_text);
+                            if !display.is_empty() {
+                                let _ = bus
+                                    .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                                        text: display,
+                                        is_final: false,
+                                        confidence: 0.85,
+                                        session_id,
+                                    }))
+                                    .await;
+                            }
                         }
                         Ok(Ok(_)) => {}
                         Ok(Err(_)) => tracing::warn!("listen[parakeet]: worker channel closed"),
@@ -678,17 +688,8 @@ impl SttActor {
                             reply: reply_tx,
                         });
                         match tokio::time::timeout(Duration::from_millis(800), reply_rx).await {
-                            Ok(Ok(text)) if !text.trim().is_empty() => {
-                                let _ = bus
-                                    .broadcast(Event::Speech(
-                                        SpeechEvent::ListenModeTranscription {
-                                            text: text.trim().to_string(),
-                                            is_final: true,
-                                            confidence: 0.85,
-                                            session_id,
-                                        },
-                                    ))
-                                    .await;
+                            Ok(Ok(token)) if !token.trim().is_empty() => {
+                                self.parakeet_session_text.push_str(&token);
                             }
                             Ok(Ok(_)) => {}
                             Ok(Err(_)) => {
@@ -697,8 +698,21 @@ impl SttActor {
                             Err(_) => tracing::warn!("listen[parakeet]: flush timeout"),
                         }
                     }
-                    self.parakeet_chunk_accumulator.clear();
                 }
+                // Emit final transcription from accumulated session text.
+                let final_text = Self::decode_parakeet_tokens(&self.parakeet_session_text);
+                if !final_text.is_empty() {
+                    let _ = bus
+                        .broadcast(Event::Speech(SpeechEvent::ListenModeTranscription {
+                            text: final_text,
+                            is_final: true,
+                            confidence: 0.85,
+                            session_id,
+                        }))
+                        .await;
+                }
+                self.parakeet_chunk_accumulator.clear();
+                self.parakeet_session_text.clear();
             }
         } else {
             // ── Whisper fallback path ─────────────────────────────────────────────────
@@ -793,9 +807,19 @@ impl SttActor {
         }
     }
 
+    /// Post-process raw Parakeet-EOU SentencePiece tokens into readable text.
+    ///
+    /// Parakeet emits tokens like `_hello`, `_world` where a leading `_` means
+    /// "space before this word" (the SentencePiece convention). This function
+    /// converts that token stream into a properly spaced string.
+    ///
+    /// Example: `"_my_name_is"` → `"my name is"`.
+    fn decode_parakeet_tokens(tokens: &str) -> String {
+        tokens.replace('_', " ").trim().to_string()
+    }
+
     /// Convert a string backend name to SttBackend enum.
-    fn parse_backend_name(backend_str: &str) -> Result<SttBackend, String> {
-        match backend_str.to_lowercase().as_str() {
+    fn parse_backend_name(backend_str: &str) -> Result<SttBackend, String> {        match backend_str.to_lowercase().as_str() {
             "whisper" => Ok(SttBackend::Whisper),
             "sherpa" => Ok(SttBackend::Sherpa),
             "parakeet" => Ok(SttBackend::Parakeet),
@@ -957,6 +981,7 @@ impl Actor for SttActor {
                                 }
                                 self.parakeet_listen_active = false;
                                 self.parakeet_chunk_accumulator.clear();
+                                self.parakeet_session_text.clear();
                                 self.listen_audio_rx = None;
                                 self.listen_audio_stream = None;
                             }
@@ -999,6 +1024,7 @@ impl Actor for SttActor {
                             self.parakeet_worker_tx = parakeet_worker;
                             self.parakeet_listen_active = self.parakeet_worker_tx.is_some();
                             self.parakeet_chunk_accumulator.clear();
+                            self.parakeet_session_text.clear();
 
                             let config = AudioInputConfig {
                                 sample_rate: 16_000,
@@ -1029,6 +1055,7 @@ impl Actor for SttActor {
                                     }
                                     self.parakeet_listen_active = false;
                                     self.parakeet_chunk_accumulator.clear();
+                                    self.parakeet_session_text.clear();
                                     let _ = bus
                                         .broadcast(Event::Speech(SpeechEvent::ListenModeStopped {
                                             session_id,
@@ -1049,6 +1076,7 @@ impl Actor for SttActor {
                                 }
                                 self.parakeet_listen_active = false;
                                 self.parakeet_chunk_accumulator.clear();
+                                self.parakeet_session_text.clear();
                                 self.listen_session_id = None;
                                 self.listen_audio_rx = None;
                                 self.listen_audio_stream = None;
@@ -1188,6 +1216,7 @@ impl Actor for SttActor {
         }
         self.parakeet_listen_active = false;
         self.parakeet_chunk_accumulator.clear();
+        self.parakeet_session_text.clear();
         self.audio_rx = None;
         self.audio_stream = None;
         self.listen_audio_rx = None;

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -264,7 +264,7 @@ impl SttActor {
             .clone()
             .ok_or_else(|| SpeechError::SttInitFailed("model_dir not configured".to_string()))?;
 
-        let sherpa_model_dir = model_dir.join("sherpa");
+        let sherpa_model_dir = model_dir.join("sherpa-streaming");
 
         // Guard: check model files exist before calling into C library.
         // The sherpa-onnx C++ library will abort() the process on certain errors
@@ -939,10 +939,9 @@ impl Actor for SttActor {
                                     session_id,
                                     self.listen_session_id
                                 );
-                                // Shut down the previous sherpa worker if any.
-                                if let Some(old_tx) = self.sherpa_worker_tx.take() {
-                                    let _ = old_tx.send(SherpaCmd::Shutdown);
-                                }
+                                // Release the listen-mode sherpa sender WITHOUT killing the
+                                // actor-lifetime worker (only stop() and shutdown_backend do that).
+                                self.sherpa_worker_tx = None;
                                 self.sherpa_listen_active = false;
                                 // Shut down the previous parakeet worker if any.
                                 if let Some(old_tx) = self.parakeet_worker_tx.take() {
@@ -983,6 +982,12 @@ impl Actor for SttActor {
                             self.sherpa_worker_tx = sherpa_worker;
                             self.sherpa_listen_active = self.sherpa_worker_tx.is_some();
                             self.listen_last_sherpa = None;
+                            // Reset Sherpa stream so previous session state doesn't bleed in.
+                            if self.sherpa_listen_active {
+                                if let Some(tx) = &self.sherpa_worker_tx {
+                                    let _ = tx.send(SherpaCmd::ResetStream);
+                                }
+                            }
                             self.parakeet_worker_tx = parakeet_worker;
                             self.parakeet_listen_active = self.parakeet_worker_tx.is_some();
                             self.parakeet_chunk_accumulator.clear();
@@ -1007,10 +1012,8 @@ impl Actor for SttActor {
                                 }
                                 Err(e) => {
                                     tracing::error!("listen: failed to start audio capture: {}", e);
-                                    // Clean up sherpa worker if audio failed.
-                                    if let Some(tx) = self.sherpa_worker_tx.take() {
-                                        let _ = tx.send(SherpaCmd::Shutdown);
-                                    }
+                                    // Release sherpa listen reference WITHOUT killing actor-lifetime worker.
+                                    self.sherpa_worker_tx = None;
                                     self.sherpa_listen_active = false;
                                     // Clean up parakeet worker if audio failed.
                                     if let Some(tx) = self.parakeet_worker_tx.take() {
@@ -1028,10 +1031,8 @@ impl Actor for SttActor {
                         }
                         Ok(Event::Speech(SpeechEvent::ListenModeStopRequested { session_id })) => {
                             if self.listen_session_id == Some(session_id) {
-                                // Shut down sherpa worker if active.
-                                if let Some(tx) = self.sherpa_worker_tx.take() {
-                                    let _ = tx.send(SherpaCmd::Shutdown);
-                                }
+                                // Release sherpa listen reference WITHOUT killing the actor-lifetime worker.
+                                self.sherpa_worker_tx = None;
                                 self.sherpa_listen_active = false;
                                 self.listen_last_sherpa = None;
                                 // Shut down parakeet worker if active.
@@ -1253,6 +1254,8 @@ enum SherpaCmd {
         samples: Vec<f32>,
         reply: oneshot::Sender<String>,
     },
+    /// Reset the internal stream for a new listen session.
+    ResetStream,
     Shutdown,
 }
 
@@ -1264,6 +1267,9 @@ fn sherpa_worker_loop(
     while let Ok(cmd) = rx.recv() {
         match cmd {
             SherpaCmd::Shutdown => break,
+            SherpaCmd::ResetStream => {
+                model.reset_stream();
+            }
             SherpaCmd::Decode { samples, reply } => {
                 let text = model.decode_chunk(samples);
                 let _ = reply.send(text);
@@ -1296,9 +1302,13 @@ fn parakeet_worker_loop(
         match command {
             ParakeetCommand::Shutdown => break,
             ParakeetCommand::Chunk { samples, reply } => {
-                let text = model
-                    .decode_chunk_f32(&samples)
-                    .unwrap_or_default();
+                let text = match model.decode_chunk_f32(&samples) {
+                    Ok(t) => t,
+                    Err(e) => {
+                        tracing::warn!("parakeet: chunk decode failed: {}", e);
+                        String::new()
+                    }
+                };
                 let _ = reply.send(text);
             }
             ParakeetCommand::Transcribe { samples, reply } => {

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -213,6 +213,8 @@ impl SttActor {
         let handle = match self.backend {
             SttBackend::Mock => SttBackendHandle::Mock,
             SttBackend::Whisper => self.initialize_candle_backend().await?,
+            SttBackend::Sherpa => SttBackendHandle::Sherpa,
+            SttBackend::Parakeet => SttBackendHandle::Parakeet,
         };
 
         self.backend_handle = Some(handle);
@@ -295,6 +297,12 @@ impl SttActor {
                     SpeechError::TranscriptionFailed(format!("candle worker reply failed: {}", e))
                 })?
             }
+            Some(SttBackendHandle::Sherpa) => Err(SpeechError::TranscriptionFailed(
+                "Sherpa backend not yet implemented".to_string(),
+            )),
+            Some(SttBackendHandle::Parakeet) => Err(SpeechError::TranscriptionFailed(
+                "Parakeet backend not yet implemented".to_string(),
+            )),
             None => Err(SpeechError::TranscriptionFailed(
                 "STT backend not initialized".to_string(),
             )),
@@ -787,6 +795,10 @@ enum SttBackendHandle {
     CandleWhisper {
         tx: std::sync::mpsc::Sender<WorkerCommand>,
     },
+    /// Sherpa backend placeholder (implementation in Unit 3).
+    Sherpa,
+    /// Parakeet backend placeholder (implementation in Unit 4).
+    Parakeet,
 }
 
 enum WorkerCommand {

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -19,7 +19,7 @@ const DEFAULT_BUFFER_DURATION_SECS: f32 = 3.0;
 const LISTEN_WHISPER_BUFFER_DURATION_SECS: f32 = 1.0;
 
 /// Maximum rolling audio retained for listen-mode interim transcriptions (6 seconds at 16kHz).
-const LISTEN_ROLLING_MAX_SAMPLES: usize = 16_000 * 6;
+const LISTEN_ROLLING_MAX_SAMPLES: usize = 16_000 * 3;
 
 /// Minimum audio accumulated before first interim transcription attempt (2s at 16kHz).
 const LISTEN_INTERIM_MIN_SAMPLES: usize = 16_000 * 2;
@@ -306,14 +306,17 @@ impl SttActor {
         }
 
         // Emit interim (non-final) transcription every LISTEN_INTERIM_INTERVAL
-        // once at least 2s of audio has accumulated.
+        // once at least 2s of audio has accumulated AND audio is not silent.
         let enough_audio = self.listen_rolling_samples.len() >= LISTEN_INTERIM_MIN_SAMPLES;
         let interval_elapsed = self
             .listen_last_interim
             .map(|t| t.elapsed() >= LISTEN_INTERIM_INTERVAL)
             .unwrap_or(true);
+        // Gate: skip if rolling buffer is mostly silence (avoids Whisper hallucinations).
+        let rolling_rms = crate::silence_detector::calculate_rms(&self.listen_rolling_samples);
+        let has_speech = rolling_rms > self.stt_energy_threshold;
 
-        if enough_audio && interval_elapsed {
+        if enough_audio && interval_elapsed && has_speech {
             let interim_buf = AudioBuffer {
                 samples: self.listen_rolling_samples.clone(),
                 sample_rate: buffer.sample_rate,

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -477,8 +477,49 @@ impl SttActor {
         request_id: u64,
         bus: &Arc<EventBus>,
     ) {
+        // Calculate chunk duration from audio buffer
+        let chunk_duration_ms =
+            (buffer.samples.len() as f64 / buffer.sample_rate as f64 * 1000.0) as u64;
+
+        // Track latency (time from transcribe start to result)
+        let start = std::time::Instant::now();
+
         match tokio::time::timeout(TRANSCRIPTION_TIMEOUT, self.transcribe(buffer)).await {
             Ok(Ok(result)) => {
+                let latency_ms = start.elapsed().as_millis() as u64;
+
+                // Determine backend name and VRAM
+                let (backend_name, vram_mb) = match self.backend {
+                    SttBackend::Whisper => ("whisper", 142),
+                    SttBackend::Sherpa => ("sherpa", 100),
+                    SttBackend::Parakeet => ("parakeet", 480),
+                    SttBackend::Mock => ("mock", 0),
+                };
+
+                // Log telemetry (non-fatal failure — log error but continue)
+                if let Err(e) = crate::telemetry::log_stt_telemetry(
+                    backend_name,
+                    chunk_duration_ms,
+                    latency_ms,
+                    result.confidence as f64,
+                    vram_mb,
+                )
+                .await
+                {
+                    tracing::warn!("telemetry write failed: {}", e);
+                }
+
+                // Broadcast telemetry event
+                let _ = bus
+                    .broadcast(Event::Speech(SpeechEvent::SttTelemetryUpdate {
+                        backend: backend_name.to_string(),
+                        vram_mb: Some(vram_mb as f64),
+                        latency_ms: latency_ms as f64,
+                        avg_confidence: result.confidence as f64,
+                        request_id,
+                    }))
+                    .await;
+
                 if result.confidence >= self.confidence_threshold {
                     let _ = bus
                         .broadcast(Event::Speech(SpeechEvent::TranscriptionCompleted {

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -164,63 +164,6 @@ impl SttActor {
         self
     }
 
-    async fn init_sherpa_backend(
-        &self,
-        model_dir: &std::path::Path,
-    ) -> Option<std::sync::mpsc::Sender<SherpaCmd>> {
-        let encoder = model_dir
-            .join("sherpa_encoder.onnx")
-            .to_string_lossy()
-            .into_owned();
-        let decoder = model_dir
-            .join("sherpa_decoder.onnx")
-            .to_string_lossy()
-            .into_owned();
-        let joiner = model_dir
-            .join("sherpa_joiner.onnx")
-            .to_string_lossy()
-            .into_owned();
-        let tokens = model_dir
-            .join("sherpa_tokens.txt")
-            .to_string_lossy()
-            .into_owned();
-
-        // Create channels for worker thread communication
-        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<SherpaCmd>();
-        let (init_tx, init_rx) = std::sync::mpsc::channel::<Result<(), SpeechError>>();
-
-        // Spawn worker thread that creates and owns the model
-        std::thread::spawn(move || {
-            // Load model in this thread (sherpa-onnx types are not Send)
-            match crate::sherpa_stt::SherpaZipformerStt::load(&encoder, &decoder, &joiner, &tokens)
-            {
-                Ok(model) => {
-                    // Signal successful initialization
-                    let _ = init_tx.send(Ok(()));
-                    // Run worker loop
-                    sherpa_worker_loop(model, cmd_rx);
-                }
-                Err(e) => {
-                    // Signal initialization failure
-                    let _ = init_tx.send(Err(e));
-                }
-            }
-        });
-
-        // Wait for initialization to complete
-        match init_rx.recv() {
-            Ok(Ok(())) => Some(cmd_tx),
-            Ok(Err(e)) => {
-                tracing::warn!("listen: sherpa init failed, falling back to whisper: {}", e);
-                None
-            }
-            Err(e) => {
-                tracing::warn!("listen: sherpa worker init channel failed: {}", e);
-                None
-            }
-        }
-    }
-
     fn next_request_id(&mut self) -> u64 {
         let id = self.request_id_counter;
         self.request_id_counter = self.request_id_counter.saturating_add(1);
@@ -269,6 +212,14 @@ impl SttActor {
 
         let parakeet_model_dir = model_dir.join("parakeet");
 
+        // Guard: check model files exist before calling into C library
+        if !crate::parakeet_stt::ParakeetStt::models_present(&parakeet_model_dir) {
+            return Err(SpeechError::SttInitFailed(format!(
+                "Parakeet models not found in {}; run /models download to fetch them",
+                parakeet_model_dir.display()
+            )));
+        }
+
         tracing::info!(
             "initializing Parakeet backend from {}",
             parakeet_model_dir.display()
@@ -298,6 +249,16 @@ impl SttActor {
             .ok_or_else(|| SpeechError::SttInitFailed("model_dir not configured".to_string()))?;
 
         let sherpa_model_dir = model_dir.join("sherpa");
+
+        // Guard: check model files exist before calling into C library.
+        // The sherpa-onnx C++ library will abort() the process on certain errors
+        // (e.g. wrong ONNX format), so we must validate up front.
+        if !crate::sherpa_stt::SherpaZipformerStt::models_present(&sherpa_model_dir) {
+            return Err(SpeechError::SttInitFailed(format!(
+                "Sherpa models not found in {}; run /models download to fetch them",
+                sherpa_model_dir.display()
+            )));
+        }
 
         tracing::info!(
             "initializing Sherpa backend from {}",
@@ -895,15 +856,14 @@ impl Actor for SttActor {
                                 self.listen_audio_stream = None;
                             }
 
-                            // Try to initialise sherpa if models are present.
-                            let sherpa_worker = if let Some(ref dir) = self.model_dir.clone() {
-                                if crate::sherpa_stt::SherpaZipformerStt::models_present(dir) {
-                                    self.init_sherpa_backend(dir).await
-                                } else {
-                                    None
+                            // Use Sherpa for listen-mode streaming only when Sherpa is the
+                            // active, already-initialized backend. Cloning the sender is safe —
+                            // mpsc::Sender is Clone and the worker loop handles commands serially.
+                            let sherpa_worker = match (&self.backend, &self.backend_handle) {
+                                (SttBackend::Sherpa, Some(SttBackendHandle::Sherpa { tx })) => {
+                                    Some(tx.clone())
                                 }
-                            } else {
-                                None
+                                _ => None,
                             };
 
                             let (buffer_duration, backend_label) = if sherpa_worker.is_some() {

--- a/crates/speech/src/stt_actor.rs
+++ b/crates/speech/src/stt_actor.rs
@@ -182,22 +182,37 @@ impl SttActor {
             .to_string_lossy()
             .into_owned();
 
-        match tokio::task::spawn_blocking(move || {
-            crate::sherpa_stt::SherpaZipformerStt::load(&encoder, &decoder, &joiner, &tokens)
-        })
-        .await
-        {
-            Ok(Ok(model)) => {
-                let (tx, rx) = std::sync::mpsc::channel::<SherpaCmd>();
-                std::thread::spawn(move || sherpa_worker_loop(model, rx));
-                Some(tx)
+        // Create channels for worker thread communication
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<SherpaCmd>();
+        let (init_tx, init_rx) = std::sync::mpsc::channel::<Result<(), SpeechError>>();
+
+        // Spawn worker thread that creates and owns the model
+        std::thread::spawn(move || {
+            // Load model in this thread (sherpa-onnx types are not Send)
+            match crate::sherpa_stt::SherpaZipformerStt::load(&encoder, &decoder, &joiner, &tokens)
+            {
+                Ok(model) => {
+                    // Signal successful initialization
+                    let _ = init_tx.send(Ok(()));
+                    // Run worker loop
+                    sherpa_worker_loop(model, cmd_rx);
+                }
+                Err(e) => {
+                    // Signal initialization failure
+                    let _ = init_tx.send(Err(e));
+                }
             }
+        });
+
+        // Wait for initialization to complete
+        match init_rx.recv() {
+            Ok(Ok(())) => Some(cmd_tx),
             Ok(Err(e)) => {
                 tracing::warn!("listen: sherpa init failed, falling back to whisper: {}", e);
                 None
             }
             Err(e) => {
-                tracing::warn!("listen: sherpa spawn_blocking panicked: {}", e);
+                tracing::warn!("listen: sherpa worker init channel failed: {}", e);
                 None
             }
         }
@@ -213,7 +228,7 @@ impl SttActor {
         let handle = match self.backend {
             SttBackend::Mock => SttBackendHandle::Mock,
             SttBackend::Whisper => self.initialize_candle_backend().await?,
-            SttBackend::Sherpa => SttBackendHandle::Sherpa,
+            SttBackend::Sherpa => self.initialize_sherpa_backend().await?,
             SttBackend::Parakeet => self.initialize_parakeet_backend().await?,
         };
 
@@ -273,6 +288,76 @@ impl SttActor {
         Ok(SttBackendHandle::Parakeet { tx: cmd_tx })
     }
 
+    async fn initialize_sherpa_backend(&self) -> Result<SttBackendHandle, SpeechError> {
+        let model_dir = self
+            .model_dir
+            .clone()
+            .ok_or_else(|| SpeechError::SttInitFailed("model_dir not configured".to_string()))?;
+
+        let sherpa_model_dir = model_dir.join("sherpa");
+
+        tracing::info!(
+            "initializing Sherpa backend from {}",
+            sherpa_model_dir.display()
+        );
+
+        // Build model file paths
+        let encoder = sherpa_model_dir
+            .join("sherpa_encoder.onnx")
+            .to_str()
+            .ok_or_else(|| SpeechError::SttInitFailed("non-UTF-8 path for encoder".to_string()))?
+            .to_string();
+
+        let decoder = sherpa_model_dir
+            .join("sherpa_decoder.onnx")
+            .to_str()
+            .ok_or_else(|| SpeechError::SttInitFailed("non-UTF-8 path for decoder".to_string()))?
+            .to_string();
+
+        let joiner = sherpa_model_dir
+            .join("sherpa_joiner.onnx")
+            .to_str()
+            .ok_or_else(|| SpeechError::SttInitFailed("non-UTF-8 path for joiner".to_string()))?
+            .to_string();
+
+        let tokens = sherpa_model_dir
+            .join("sherpa_tokens.txt")
+            .to_str()
+            .ok_or_else(|| SpeechError::SttInitFailed("non-UTF-8 path for tokens".to_string()))?
+            .to_string();
+
+        // Create channel for worker thread communication
+        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel::<SherpaCmd>();
+        let (init_tx, init_rx) = std::sync::mpsc::channel::<Result<(), SpeechError>>();
+
+        // Spawn worker thread that creates and owns the model
+        std::thread::spawn(move || {
+            // Load model in this thread (sherpa-onnx types are not Send)
+            match crate::sherpa_stt::SherpaZipformerStt::load(&encoder, &decoder, &joiner, &tokens)
+            {
+                Ok(model) => {
+                    // Signal successful initialization
+                    let _ = init_tx.send(Ok(()));
+                    // Run worker loop
+                    sherpa_worker_loop(model, cmd_rx);
+                }
+                Err(e) => {
+                    // Signal initialization failure
+                    let _ = init_tx.send(Err(e));
+                }
+            }
+        });
+
+        // Wait for initialization to complete
+        init_rx.recv().map_err(|e| {
+            SpeechError::SttInitFailed(format!("sherpa worker init channel failed: {}", e))
+        })??;
+
+        tracing::info!("Sherpa backend initialized successfully");
+
+        Ok(SttBackendHandle::Sherpa { tx: cmd_tx })
+    }
+
     fn maybe_start_audio_capture(&mut self) -> Result<(), SpeechError> {
         if !self.voice_always_listening {
             return Ok(());
@@ -327,9 +412,35 @@ impl SttActor {
                     SpeechError::TranscriptionFailed(format!("candle worker reply failed: {}", e))
                 })?
             }
-            Some(SttBackendHandle::Sherpa) => Err(SpeechError::TranscriptionFailed(
-                "Sherpa backend not yet implemented".to_string(),
-            )),
+            Some(SttBackendHandle::Sherpa { tx }) => {
+                // Calculate confidence from audio energy before moving samples
+                let rms = crate::silence_detector::calculate_rms(&buffer.samples);
+
+                let (reply_tx, reply_rx) = oneshot::channel();
+                tx.send(SherpaCmd::Decode {
+                    samples: buffer.samples,
+                    reply: reply_tx,
+                })
+                .map_err(|e| {
+                    SpeechError::TranscriptionFailed(format!(
+                        "sherpa worker channel send failed: {}",
+                        e
+                    ))
+                })?;
+
+                let text = reply_rx.await.map_err(|e| {
+                    SpeechError::TranscriptionFailed(format!("sherpa worker reply failed: {}", e))
+                })?;
+
+                // Calculate confidence from audio energy
+                let confidence = if text.trim().is_empty() {
+                    0.0
+                } else {
+                    (rms * 10.0).clamp(0.55, 0.99)
+                };
+
+                Ok(TranscriptionResult { text, confidence })
+            }
             Some(SttBackendHandle::Parakeet { tx }) => {
                 // Convert f32 samples to i16 for parakeet
                 let samples_i16: Vec<i16> = buffer
@@ -837,6 +948,9 @@ impl Actor for SttActor {
             Some(SttBackendHandle::CandleWhisper { tx }) => {
                 let _ = tx.send(WorkerCommand::Shutdown);
             }
+            Some(SttBackendHandle::Sherpa { tx }) => {
+                let _ = tx.send(SherpaCmd::Shutdown);
+            }
             Some(SttBackendHandle::Parakeet { tx }) => {
                 let _ = tx.send(ParakeetCommand::Shutdown);
             }
@@ -852,8 +966,10 @@ enum SttBackendHandle {
     CandleWhisper {
         tx: std::sync::mpsc::Sender<WorkerCommand>,
     },
-    /// Sherpa backend placeholder (implementation in Unit 3).
-    Sherpa,
+    /// Sherpa backend — sherpa-onnx Zipformer ONNX Transducer streaming STT.
+    Sherpa {
+        tx: std::sync::mpsc::Sender<SherpaCmd>,
+    },
     /// Parakeet backend — NVIDIA Parakeet-EOU ONNX streaming STT.
     Parakeet {
         tx: std::sync::mpsc::Sender<ParakeetCommand>,

--- a/crates/speech/src/telemetry.rs
+++ b/crates/speech/src/telemetry.rs
@@ -1,0 +1,157 @@
+//! STT telemetry logging to CSV.
+//!
+//! Records backend performance metrics (latency, VRAM, confidence) for A/B testing analysis.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::SpeechError;
+
+/// Log STT telemetry to CSV file.
+///
+/// Logs to platform-specific path:
+/// - Windows: `%APPDATA%\sena\logs\stt_telemetry.csv`
+/// - macOS: `~/Library/Application Support/sena/logs/stt_telemetry.csv`
+/// - Linux: `~/.config/sena/logs/stt_telemetry.csv`
+///
+/// CSV format: `backend,chunk_duration_ms,latency_ms,confidence,vram_mb`
+///
+/// Writes CSV header on first write (when file does not exist or is empty).
+pub async fn log_stt_telemetry(
+    backend: &str,
+    chunk_duration_ms: u64,
+    latency_ms: u64,
+    confidence: f64,
+    vram_mb: u32,
+) -> Result<(), SpeechError> {
+    let log_path = telemetry_log_path()?;
+
+    // Ensure log directory exists
+    if let Some(parent) = log_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| SpeechError::TelemetryWriteFailed(e.to_string()))?;
+    }
+
+    // Check if header is needed (file doesn't exist or is empty)
+    let needs_header = !log_path.exists()
+        || tokio::fs::metadata(&log_path)
+            .await
+            .map_err(|e| SpeechError::TelemetryWriteFailed(e.to_string()))?
+            .len()
+            == 0;
+
+    let mut lines = String::new();
+    if needs_header {
+        lines.push_str("backend,chunk_duration_ms,latency_ms,confidence,vram_mb\n");
+    }
+    lines.push_str(&format!(
+        "{},{},{},{:.3},{}\n",
+        backend, chunk_duration_ms, latency_ms, confidence, vram_mb
+    ));
+
+    // Offload blocking file I/O to tokio's blocking thread pool
+    let log_path_clone = log_path.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path_clone)
+            .map_err(|e| SpeechError::TelemetryWriteFailed(e.to_string()))?;
+        file.write_all(lines.as_bytes())
+            .map_err(|e| SpeechError::TelemetryWriteFailed(e.to_string()))?;
+        file.flush()
+            .map_err(|e| SpeechError::TelemetryWriteFailed(e.to_string()))?;
+        Ok::<_, SpeechError>(())
+    })
+    .await
+    .map_err(|e| SpeechError::TelemetryWriteFailed(e.to_string()))??;
+
+    tracing::debug!(
+        "telemetry: logged STT metrics — backend={}, chunk={}ms, latency={}ms, confidence={:.3}, vram={}MB",
+        backend, chunk_duration_ms, latency_ms, confidence, vram_mb
+    );
+
+    Ok(())
+}
+
+/// Get platform-specific telemetry log path.
+fn telemetry_log_path() -> Result<PathBuf, SpeechError> {
+    let base_dir = if cfg!(target_os = "windows") {
+        std::env::var("APPDATA")
+            .map_err(|_| SpeechError::TelemetryWriteFailed("APPDATA env var not set".to_string()))
+            .map(PathBuf::from)?
+    } else if cfg!(target_os = "macos") {
+        std::env::var("HOME")
+            .map_err(|_| SpeechError::TelemetryWriteFailed("HOME env var not set".to_string()))
+            .map(|home| {
+                PathBuf::from(home)
+                    .join("Library")
+                    .join("Application Support")
+            })?
+    } else {
+        // Linux
+        std::env::var("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .or_else(|_| {
+                std::env::var("HOME")
+                    .map(|home| PathBuf::from(home).join(".config"))
+                    .map_err(|_| {
+                        SpeechError::TelemetryWriteFailed("HOME env var not set".to_string())
+                    })
+            })?
+    };
+
+    Ok(base_dir.join("sena").join("logs").join("stt_telemetry.csv"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn telemetry_log_path_returns_valid_path() {
+        let path = telemetry_log_path();
+        assert!(path.is_ok());
+        let path = path.unwrap();
+        assert!(path.to_string_lossy().contains("sena"));
+        assert!(path.to_string_lossy().contains("logs"));
+        assert!(path.to_string_lossy().ends_with("stt_telemetry.csv"));
+    }
+
+    #[tokio::test]
+    async fn log_stt_telemetry_writes_csv_with_header() {
+        use tempfile::tempdir;
+
+        let _temp_dir = tempdir().unwrap();
+
+        // Simulate writing to temp file by testing the format string
+        let mut lines = String::new();
+        lines.push_str("backend,chunk_duration_ms,latency_ms,confidence,vram_mb\n");
+        lines.push_str(&format!(
+            "{},{},{},{:.3},{}\n",
+            "whisper", 560, 342, 0.987, 142
+        ));
+
+        assert!(lines.contains("backend,chunk_duration_ms,latency_ms,confidence,vram_mb"));
+        assert!(lines.contains("whisper,560,342,0.987,142"));
+    }
+
+    #[tokio::test]
+    async fn log_stt_telemetry_formats_correctly() {
+        // Test format string generation
+        let backend = "sherpa";
+        let chunk_duration_ms = 200;
+        let latency_ms = 124;
+        let confidence = 0.956;
+        let vram_mb = 100;
+
+        let line = format!(
+            "{},{},{},{:.3},{}\n",
+            backend, chunk_duration_ms, latency_ms, confidence, vram_mb
+        );
+
+        assert_eq!(line, "sherpa,200,124,0.956,100\n");
+    }
+}

--- a/crates/speech/src/tts_actor.rs
+++ b/crates/speech/src/tts_actor.rs
@@ -130,10 +130,8 @@ impl TtsActor {
         let assertiveness_delta = (assertiveness as f32 - 50.0) / 50.0;
         let brevity_delta = (brevity as f32 - 50.0) / 50.0;
 
-        let modifier = 1.0
-            + (assertiveness_delta * 0.08)
-            + (brevity_delta * 0.06)
-            - (warmth_delta * 0.06);
+        let modifier =
+            1.0 + (assertiveness_delta * 0.08) + (brevity_delta * 0.06) - (warmth_delta * 0.06);
 
         modifier.clamp(0.8, 1.2)
     }


### PR DESCRIPTION
This PR wires the 9 previously orphaned events into their existing handling paths, preserves Soul export stub semantics, and adds the /export CLI command path.

Key changes:
- Inference caches RichSummaryReady and uses it as a prompt fallback
- CTP receives IdentitySignalDistilled, TemporalPatternDetected, and InferenceRoundCompleted
- Runtime logs SttTelemetryUpdate and SemanticIngestComplete
- STT subscribes to WakewordSuppressed/WakewordResumed
- Inference logs MemoryEvent::WriteCompleted
- Soul export now returns NotImplemented("export") instead of an unconditional failure broadcast
- CLI and IPC /export dispatch paths added

Validation: cargo check --workspace and cargo clippy --workspace -- -D warnings both pass.
