### PR TITLE
runtime: restore config application and adaptive tuning

### DIFF
--- a/sena/crates/bus/src/events/system.rs
+++ b/sena/crates/bus/src/events/system.rs
@@ -115,6 +115,15 @@ pub enum SystemEvent {
         /// Failure reason.
         reason: String,
     },
+    /// inference_max_tokens was automatically adjusted based on observed usage.
+    TokenBudgetAutoTuned {
+        /// Previous token limit.
+        old_max_tokens: usize,
+        /// New token limit after tuning.
+        new_max_tokens: usize,
+        /// P95 token count from the observation window that drove this decision.
+        p95_tokens: usize,
+    },
     /// System wake event — emitted when OS wakes from sleep.
     SystemWake,
     /// System sleep event — emitted when OS is about to sleep.
@@ -242,6 +251,16 @@ mod tests {
             reason: "speech models unavailable".to_string(),
         };
         assert!(matches!(event, SystemEvent::BootFailed { .. }));
+    }
+
+    #[test]
+    fn token_budget_auto_tuned_event_constructs() {
+        let event = SystemEvent::TokenBudgetAutoTuned {
+            old_max_tokens: 512,
+            new_max_tokens: 768,
+            p95_tokens: 640,
+        };
+        assert!(matches!(event, SystemEvent::TokenBudgetAutoTuned { .. }));
     }
 
     #[test]

--- a/sena/crates/daemon/src/commands/config_commands.rs
+++ b/sena/crates/daemon/src/commands/config_commands.rs
@@ -22,13 +22,33 @@ impl CommandHandler for ConfigGetHandler {
             IpcError::InvalidPayload("missing or invalid 'key' field".to_string())
         })?;
 
-        // Phase 2 limitation: no runtime config subsystem yet.
-        // Return null value with note.
-        Ok(json!({
-            "key": key,
-            "value": null,
-            "note": "Config subsystem not yet implemented"
-        }))
+        let config = runtime::load_or_create_config()
+            .await
+            .map_err(|e| IpcError::Internal(format!("failed to load config: {}", e)))?;
+
+        let value = match key {
+            "file_watch_paths" => json!(
+                config
+                    .file_watch_paths
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+            ),
+            "clipboard_observation_enabled" => json!(config.clipboard_observation_enabled),
+            "speech_enabled" => json!(config.speech_enabled),
+            "inference_max_tokens" => json!(config.inference_max_tokens),
+            "auto_tune_tokens" => json!(config.auto_tune_tokens),
+            "auto_tune_min_tokens" => json!(config.auto_tune_min_tokens),
+            "auto_tune_max_tokens" => json!(config.auto_tune_max_tokens),
+            _ => {
+                return Err(IpcError::InvalidPayload(format!(
+                    "unknown config key '{}'",
+                    key
+                )));
+            }
+        };
+
+        Ok(json!({ "key": key, "value": value }))
     }
 }
 
@@ -50,14 +70,22 @@ impl CommandHandler for ConfigSetHandler {
             IpcError::InvalidPayload("missing or invalid 'key' field".to_string())
         })?;
 
-        let _value = payload
+        let value = payload
             .get("value")
-            .ok_or_else(|| IpcError::InvalidPayload("missing 'value' field".to_string()))?;
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                IpcError::InvalidPayload("missing or invalid 'value' field".to_string())
+            })?;
 
-        // Phase 2 limitation: no runtime config subsystem yet.
-        Err(IpcError::CommandNotReady(format!(
-            "Config write not yet implemented (key: {})",
-            key
-        )))
+        runtime::config::apply_config_set(key, value)
+            .await
+            .map_err(IpcError::CommandFailed)?;
+
+        Ok(json!({
+            "key": key,
+            "value": value,
+            "saved": true,
+            "restart_required": true,
+        }))
     }
 }

--- a/sena/crates/daemon/src/main.rs
+++ b/sena/crates/daemon/src/main.rs
@@ -241,6 +241,16 @@ async fn forward_bus_events_to_ipc(
                 "type": "boot_failed",
                 "reason": reason,
             })),
+            Event::System(bus::SystemEvent::TokenBudgetAutoTuned {
+                old_max_tokens,
+                new_max_tokens,
+                p95_tokens,
+            }) => Some(json!({
+                "type": "token_budget_auto_tuned",
+                "old_max_tokens": old_max_tokens,
+                "new_max_tokens": new_max_tokens,
+                "p95_tokens": p95_tokens,
+            })),
             // Loop status changed events
             Event::System(bus::SystemEvent::LoopStatusChanged { loop_name, enabled }) => {
                 Some(json!({

--- a/sena/crates/inference/src/actor.rs
+++ b/sena/crates/inference/src/actor.rs
@@ -9,7 +9,10 @@ use bus::{
     Actor, ActorError, Event, EventBus, InferenceEvent, InferenceFailureOrigin, InferenceSource,
     Priority,
 };
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 use text::SentenceBoundaryIterator;
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tracing::{debug, info, trace, warn};
@@ -25,6 +28,7 @@ pub struct InferenceActor {
     rx: Option<broadcast::Receiver<Event>>,
     directed_rx: Option<mpsc::Receiver<Event>>,
     work_tx: Option<mpsc::Sender<()>>,
+    inference_max_tokens: Arc<AtomicUsize>,
 }
 
 impl InferenceActor {
@@ -52,7 +56,15 @@ impl InferenceActor {
             rx: None,
             directed_rx: None,
             work_tx: None,
+            inference_max_tokens: Arc::new(AtomicUsize::new(InferenceParams::default().max_tokens)),
         }
+    }
+
+    /// Override the default inference token budget.
+    pub fn with_inference_max_tokens(self, max_tokens: usize) -> Self {
+        self.inference_max_tokens
+            .store(max_tokens, Ordering::Relaxed);
+        self
     }
 
     /// Handle an inference request event.
@@ -255,6 +267,7 @@ impl InferenceActor {
         bus: Arc<EventBus>,
         backend: Arc<Mutex<Box<dyn InferenceBackend>>>,
         queue: Arc<Mutex<InferenceQueue>>,
+        inference_max_tokens: Arc<AtomicUsize>,
         mut work_signal: mpsc::Receiver<()>,
     ) {
         loop {
@@ -285,6 +298,7 @@ impl InferenceActor {
                         let result = Self::execute_inference(
                             bus.clone(),
                             backend.clone(),
+                            inference_max_tokens.clone(),
                             prompt,
                             source,
                             causal_id,
@@ -320,6 +334,7 @@ impl InferenceActor {
     async fn execute_inference(
         bus: Arc<EventBus>,
         backend: Arc<Mutex<Box<dyn InferenceBackend>>>,
+        inference_max_tokens: Arc<AtomicUsize>,
         prompt: String,
         source: InferenceSource,
         causal_id: bus::CausalId,
@@ -342,8 +357,10 @@ impl InferenceActor {
             return Err(InferenceError::ModelNotLoaded);
         }
 
-        // Create inference parameters (default for now)
-        let params = InferenceParams::default();
+        let params = InferenceParams {
+            max_tokens: inference_max_tokens.load(Ordering::Relaxed),
+            ..InferenceParams::default()
+        };
 
         debug!(?params, "running inference");
 
@@ -674,9 +691,17 @@ impl Actor for InferenceActor {
         let worker_bus = bus.clone();
         let worker_backend = self.backend.clone();
         let worker_queue = self.queue.clone();
+        let worker_inference_max_tokens = self.inference_max_tokens.clone();
 
         tokio::spawn(async move {
-            Self::worker_loop(worker_bus, worker_backend, worker_queue, work_rx).await;
+            Self::worker_loop(
+                worker_bus,
+                worker_backend,
+                worker_queue,
+                worker_inference_max_tokens,
+                work_rx,
+            )
+            .await;
         });
 
         // Spawn VRAM monitoring task
@@ -714,6 +739,14 @@ impl Actor for InferenceActor {
                         Ok(Event::System(bus::SystemEvent::ShutdownSignal)) => {
                             info!("inference actor received shutdown signal");
                             break;
+                        }
+                        Ok(Event::System(bus::SystemEvent::TokenBudgetAutoTuned {
+                            new_max_tokens,
+                            ..
+                        })) => {
+                            self.inference_max_tokens
+                                .store(new_max_tokens, Ordering::Relaxed);
+                            info!(new_max_tokens, "inference actor updated token budget");
                         }
                         Ok(Event::Inference(InferenceEvent::InferenceRequested {
                             prompt,
@@ -795,6 +828,14 @@ impl Actor for InferenceActor {
 mod tests {
     use super::*;
     use crate::mock::{MockBackend, MockConfig};
+
+    #[test]
+    fn actor_allows_configured_token_budget() {
+        let backend = Box::new(MockBackend::default_loaded());
+        let actor = InferenceActor::new(backend).with_inference_max_tokens(768);
+
+        assert_eq!(actor.inference_max_tokens.load(Ordering::Relaxed), 768);
+    }
 
     #[tokio::test]
     async fn actor_handles_inference_request_when_model_loaded() {
@@ -950,5 +991,29 @@ mod tests {
         // (Hard to test exact order without exposing queue internals,
         // but we verify no crashes and all complete)
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    }
+
+    #[tokio::test]
+    async fn actor_updates_token_budget_from_auto_tune_event() {
+        let bus = Arc::new(EventBus::new());
+        let backend = Box::new(MockBackend::default_loaded());
+        let mut actor = InferenceActor::new(backend);
+        let shared_budget = actor.inference_max_tokens.clone();
+
+        actor.start(bus.clone()).await.unwrap();
+        tokio::spawn(async move {
+            let _ = actor.run().await;
+        });
+
+        bus.broadcast(Event::System(bus::SystemEvent::TokenBudgetAutoTuned {
+            old_max_tokens: 512,
+            new_max_tokens: 896,
+            p95_tokens: 700,
+        }))
+        .await
+        .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        assert_eq!(shared_budget.load(Ordering::Relaxed), 896);
     }
 }

--- a/sena/crates/platform/src/actor.rs
+++ b/sena/crates/platform/src/actor.rs
@@ -129,6 +129,7 @@ impl PlatformActor {
         window_interval: Duration,
         clipboard_interval: Duration,
         keystroke_interval: Duration,
+        clipboard_enabled: bool,
     ) {
         use bus::events::system::SystemEvent;
 
@@ -228,7 +229,7 @@ impl PlatformActor {
                 }
 
                 _ = clipboard_tick.tick() => {
-                    if !platform_polling_enabled {
+                    if !platform_polling_enabled || !clipboard_enabled {
                         continue;
                     }
                     match self.backend.clipboard_content() {

--- a/sena/crates/runtime/src/analytics.rs
+++ b/sena/crates/runtime/src/analytics.rs
@@ -1,0 +1,161 @@
+//! Local usage-based telemetry and token budget auto-tuning.
+
+use std::collections::VecDeque;
+
+/// Recommendation produced by the token tuner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenBudgetRecommendation {
+    pub recommended_tokens: usize,
+    pub p95_tokens: usize,
+}
+
+/// Rolling-window token-usage tracker and auto-tuner.
+pub struct TokenTuner {
+    recent: VecDeque<usize>,
+    window: usize,
+    tune_every: usize,
+    samples_since_tune: usize,
+    min_tokens: usize,
+    max_tokens: usize,
+}
+
+impl TokenTuner {
+    pub fn new(min_tokens: usize, max_tokens: usize) -> Self {
+        Self {
+            recent: VecDeque::new(),
+            window: 50,
+            tune_every: 10,
+            samples_since_tune: 0,
+            min_tokens,
+            max_tokens,
+        }
+    }
+
+    pub fn record(
+        &mut self,
+        token_count: usize,
+        current_limit: usize,
+    ) -> Option<TokenBudgetRecommendation> {
+        if self.recent.len() >= self.window {
+            self.recent.pop_front();
+        }
+        self.recent.push_back(token_count);
+        self.samples_since_tune += 1;
+
+        if self.samples_since_tune >= self.tune_every && self.recent.len() >= self.tune_every {
+            self.samples_since_tune = 0;
+            self.recommendation(current_limit)
+        } else {
+            None
+        }
+    }
+
+    fn recommendation(&self, current_limit: usize) -> Option<TokenBudgetRecommendation> {
+        if self.recent.is_empty() {
+            return None;
+        }
+
+        let p95_tokens = percentile_95(&self.recent);
+        let recommended_tokens = ((p95_tokens as f64 * 1.20).ceil() as usize)
+            .max(self.min_tokens)
+            .min(self.max_tokens);
+
+        let delta = (recommended_tokens as i64 - current_limit as i64).unsigned_abs() as f64;
+        let threshold = current_limit as f64 * 0.10;
+        if delta > threshold {
+            Some(TokenBudgetRecommendation {
+                recommended_tokens,
+                p95_tokens,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+fn percentile_95(counts: &VecDeque<usize>) -> usize {
+    if counts.is_empty() {
+        return 0;
+    }
+
+    let mut sorted: Vec<usize> = counts.iter().copied().collect();
+    sorted.sort_unstable();
+    let idx = ((sorted.len() as f64 * 0.95).ceil() as usize).saturating_sub(1);
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_95_single_value() {
+        let mut d = VecDeque::new();
+        d.push_back(100usize);
+        assert_eq!(percentile_95(&d), 100);
+    }
+
+    #[test]
+    fn percentile_95_returns_high_value() {
+        let mut d = VecDeque::new();
+        for i in 1..=20 {
+            d.push_back(i * 10);
+        }
+        assert_eq!(percentile_95(&d), 190);
+    }
+
+    #[test]
+    fn tuner_no_recommendation_below_window() {
+        let mut tuner = TokenTuner::new(256, 4096);
+        for _ in 0..9 {
+            assert!(tuner.record(200, 512).is_none());
+        }
+    }
+
+    #[test]
+    fn tuner_recommends_lower_budget_when_usage_is_low() {
+        let mut tuner = TokenTuner::new(256, 4096);
+        let mut result = None;
+        for _ in 0..10 {
+            result = tuner.record(100, 512);
+        }
+        let recommendation = result.expect("expected a lower recommendation");
+        assert!(recommendation.recommended_tokens < 512);
+        assert!(recommendation.recommended_tokens >= 256);
+        assert_eq!(recommendation.p95_tokens, 100);
+    }
+
+    #[test]
+    fn tuner_recommends_higher_budget_when_responses_near_limit() {
+        let mut tuner = TokenTuner::new(256, 4096);
+        let mut result = None;
+        for _ in 0..10 {
+            result = tuner.record(490, 512);
+        }
+        let recommendation = result.expect("expected a higher recommendation");
+        assert!(recommendation.recommended_tokens > 512);
+        assert!(recommendation.recommended_tokens <= 4096);
+        assert_eq!(recommendation.p95_tokens, 490);
+    }
+
+    #[test]
+    fn tuner_no_recommendation_when_budget_already_correct() {
+        let mut tuner = TokenTuner::new(256, 4096);
+        let mut result = None;
+        for _ in 0..10 {
+            result = tuner.record(430, 512);
+        }
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn tuner_respects_min_tokens_floor() {
+        let mut tuner = TokenTuner::new(300, 4096);
+        let mut result = None;
+        for _ in 0..10 {
+            result = tuner.record(10, 512);
+        }
+        let recommendation = result.expect("expected a recommendation");
+        assert!(recommendation.recommended_tokens >= 300);
+    }
+}

--- a/sena/crates/runtime/src/boot.rs
+++ b/sena/crates/runtime/src/boot.rs
@@ -21,6 +21,8 @@ const BOOT_STEP_WARN_THRESHOLD_MS: u128 = 500;
 pub struct BootResult {
     /// Event bus shared by all actors.
     pub bus: Arc<EventBus>,
+    /// Runtime configuration loaded during boot.
+    pub config: crate::config::SenaConfig,
     /// Encryption layer for encrypted storage.
     pub encryption: Arc<dyn EncryptionLayer>,
     /// Spawned actor handles with their names.
@@ -36,7 +38,7 @@ pub struct BootResult {
 /// Execute the boot sequence.
 ///
 /// Boot order:
-/// 1. Config load (stub)
+/// 1. Config load
 /// 2. Onboarding state detection
 /// 3. Encryption init
 /// 4. EventBus init
@@ -54,7 +56,7 @@ pub async fn boot() -> Result<BootResult, RuntimeError> {
     // Step 1: Config load
     let step_start = Instant::now();
     info!("Step 1/7: Loading configuration");
-    load_config().await?;
+    let config = load_config().await?;
     check_step_timing("config load", step_start);
 
     // Step 2: Onboarding state detection
@@ -107,7 +109,7 @@ pub async fn boot() -> Result<BootResult, RuntimeError> {
     // Step 7: Core actors spawn
     let step_start = Instant::now();
     info!("Step 7/7: Spawning core actors");
-    let (actor_handles, expected_actors) = spawn_actors(bus.clone()).await?;
+    let (actor_handles, expected_actors) = spawn_actors(bus.clone(), &config).await?;
     check_step_timing("actor spawn", step_start);
 
     let boot_elapsed = boot_start.elapsed();
@@ -119,6 +121,7 @@ pub async fn boot() -> Result<BootResult, RuntimeError> {
 
     Ok(BootResult {
         bus,
+        config,
         encryption,
         actor_handles,
         expected_actors,
@@ -354,14 +357,10 @@ fn hash_string(s: &str) -> u64 {
 }
 
 /// Load configuration from disk or create defaults.
-async fn load_config() -> Result<(), RuntimeError> {
-    // Load or create config using the real config module.
-    // This ensures onboarding-written config is actually read on subsequent boots.
-    let _config = crate::config::load_or_create_config()
+async fn load_config() -> Result<crate::config::SenaConfig, RuntimeError> {
+    crate::config::load_or_create_config()
         .await
-        .map_err(|e| RuntimeError::ConfigLoadFailed(e.to_string()))?;
-    tracing::debug!("config loaded successfully");
-    Ok(())
+        .map_err(|e| RuntimeError::ConfigLoadFailed(e.to_string()))
 }
 
 /// Initialize the encryption layer.
@@ -398,6 +397,7 @@ async fn init_soul(
 /// of actor names that must emit ActorReady before BootComplete.
 async fn spawn_actors(
     bus: std::sync::Arc<EventBus>,
+    config: &crate::config::SenaConfig,
 ) -> Result<
     (
         Vec<(&'static str, tokio::task::JoinHandle<()>)>,
@@ -419,7 +419,7 @@ async fn spawn_actors(
     handles.push((soul_name, soul_handle));
 
     // Step 5: Inference actor spawn
-    let inference_actor = builder::build_inference_actor()?;
+    let inference_actor = builder::build_inference_actor(config.inference_max_tokens)?;
     let inference_name: &'static str = "inference";
     expected.push(inference_name);
     let inference_handle = spawn_inference_actor(inference_actor, bus.clone());
@@ -436,7 +436,11 @@ async fn spawn_actors(
     let platform_actor = builder::build_platform_actor()?;
     let platform_name: &'static str = "platform";
     expected.push(platform_name);
-    let platform_handle = spawn_platform_actor(platform_actor, bus.clone());
+    let platform_handle = spawn_platform_actor(
+        platform_actor,
+        bus.clone(),
+        config.clipboard_observation_enabled,
+    );
     handles.push((platform_name, platform_handle));
 
     // Step 8: CTP actor spawn
@@ -457,7 +461,7 @@ async fn spawn_actors(
     handles.push((prompt_name, prompt_handle));
 
     // Speech actors are spawned conditionally (stub: always spawn for now)
-    let speech_enabled = true;
+    let speech_enabled = config.speech_enabled;
     if speech_enabled {
         // Step 10: STT actor spawn
         let stt_actor = builder::build_stt_actor(&models_dir)?;
@@ -624,6 +628,7 @@ mod poll_intervals {
 fn spawn_platform_actor(
     actor: platform::PlatformActor,
     bus: std::sync::Arc<EventBus>,
+    clipboard_enabled: bool,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let name = "platform";
@@ -640,6 +645,7 @@ fn spawn_platform_actor(
                 poll_intervals::WINDOW,
                 poll_intervals::CLIPBOARD,
                 poll_intervals::KEYSTROKE,
+                clipboard_enabled,
             )
             .await;
 
@@ -852,7 +858,8 @@ mod tests {
     #[tokio::test]
     async fn spawn_actors_creates_expected_list() {
         let bus = Arc::new(EventBus::new());
-        let result = spawn_actors(bus).await;
+        let config = crate::config::SenaConfig::default();
+        let result = spawn_actors(bus, &config).await;
         assert!(result.is_ok());
 
         let (handles, expected) = result.unwrap();
@@ -865,6 +872,22 @@ mod tests {
         assert!(expected.contains(&"prompt"));
         assert!(expected.contains(&"stt"));
         assert!(expected.contains(&"tts"));
+    }
+
+    #[tokio::test]
+    async fn spawn_actors_skips_speech_when_disabled() {
+        let bus = Arc::new(EventBus::new());
+        let config = crate::config::SenaConfig {
+            speech_enabled: false,
+            ..Default::default()
+        };
+
+        let (_handles, expected) = spawn_actors(bus, &config)
+            .await
+            .expect("spawn_actors should succeed when speech is disabled");
+
+        assert!(!expected.contains(&"stt"));
+        assert!(!expected.contains(&"tts"));
     }
 
     #[tokio::test]

--- a/sena/crates/runtime/src/builder.rs
+++ b/sena/crates/runtime/src/builder.rs
@@ -188,10 +188,13 @@ pub fn build_memory_actor() -> Result<memory::MemoryActor, RuntimeError> {
 }
 
 /// Build the inference actor with a stub backend.
-pub fn build_inference_actor() -> Result<inference::InferenceActor, RuntimeError> {
+pub fn build_inference_actor(
+    inference_max_tokens: usize,
+) -> Result<inference::InferenceActor, RuntimeError> {
     tracing::debug!("building inference actor with stub backend");
     let backend = Box::new(StubInferenceBackend);
-    let actor = inference::InferenceActor::new(backend);
+    let actor =
+        inference::InferenceActor::new(backend).with_inference_max_tokens(inference_max_tokens);
     Ok(actor)
 }
 
@@ -335,7 +338,7 @@ mod tests {
 
     #[test]
     fn inference_actor_builds() {
-        let result = build_inference_actor();
+        let result = build_inference_actor(512);
         assert!(result.is_ok());
     }
 

--- a/sena/crates/runtime/src/config.rs
+++ b/sena/crates/runtime/src/config.rs
@@ -1,13 +1,11 @@
 //! Configuration system for Sena (nested workspace).
-//!
-//! Minimal implementation to support onboarding config persistence.
 
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// Configuration for Sena runtime and subsystems.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SenaConfig {
     /// File paths to watch for changes.
     #[serde(default)]
@@ -16,19 +14,64 @@ pub struct SenaConfig {
     /// Whether clipboard observation is enabled.
     #[serde(default = "default_clipboard_observation_enabled")]
     pub clipboard_observation_enabled: bool,
+
+    /// Whether speech actors should be spawned at boot.
+    #[serde(default = "default_speech_enabled")]
+    pub speech_enabled: bool,
+
+    /// Maximum number of tokens to generate per inference response.
+    #[serde(default = "default_inference_max_tokens")]
+    pub inference_max_tokens: usize,
+
+    /// Whether local token-usage auto-tuning is enabled.
+    #[serde(default = "default_auto_tune_tokens")]
+    pub auto_tune_tokens: bool,
+
+    /// Minimum token budget the auto-tuner may select.
+    #[serde(default = "default_auto_tune_min_tokens")]
+    pub auto_tune_min_tokens: usize,
+
+    /// Maximum token budget the auto-tuner may select.
+    #[serde(default = "default_auto_tune_max_tokens")]
+    pub auto_tune_max_tokens: usize,
 }
 
 impl Default for SenaConfig {
     fn default() -> Self {
         Self {
             file_watch_paths: Vec::new(),
-            clipboard_observation_enabled: true,
+            clipboard_observation_enabled: default_clipboard_observation_enabled(),
+            speech_enabled: default_speech_enabled(),
+            inference_max_tokens: default_inference_max_tokens(),
+            auto_tune_tokens: default_auto_tune_tokens(),
+            auto_tune_min_tokens: default_auto_tune_min_tokens(),
+            auto_tune_max_tokens: default_auto_tune_max_tokens(),
         }
     }
 }
 
 fn default_clipboard_observation_enabled() -> bool {
     true
+}
+
+fn default_speech_enabled() -> bool {
+    true
+}
+
+fn default_inference_max_tokens() -> usize {
+    512
+}
+
+fn default_auto_tune_tokens() -> bool {
+    true
+}
+
+fn default_auto_tune_min_tokens() -> usize {
+    256
+}
+
+fn default_auto_tune_max_tokens() -> usize {
+    4096
 }
 
 /// Configuration errors.
@@ -78,22 +121,44 @@ pub fn config_path() -> Result<PathBuf, ConfigError> {
     Ok(config_dir()?.join("config.toml"))
 }
 
-/// Load config from disk, or create default if missing.
+/// Load config from disk, or create it with defaults when missing.
 pub async fn load_or_create_config() -> Result<SenaConfig, ConfigError> {
     let path = config_path()?;
-
-    if tokio::fs::metadata(&path).await.is_ok() {
-        let content = tokio::fs::read_to_string(&path).await?;
-        let config: SenaConfig = toml::from_str(&content)?;
-        Ok(config)
-    } else {
-        Ok(SenaConfig::default())
-    }
+    load_or_create_config_at(&path).await
 }
 
 /// Save config to disk.
 pub async fn save_config(config: &SenaConfig) -> Result<(), ConfigError> {
     let path = config_path()?;
+    save_config_at(config, &path).await
+}
+
+/// Apply a scalar config change and persist it.
+pub async fn apply_config_set(key: &str, value: &str) -> Result<(), String> {
+    let mut config = load_or_create_config()
+        .await
+        .map_err(|e| format!("failed to load config: {}", e))?;
+
+    apply_config_value(&mut config, key, value)?;
+    save_config(&config)
+        .await
+        .map_err(|e| format!("failed to save config: {}", e))?;
+    Ok(())
+}
+
+pub(crate) async fn load_or_create_config_at(path: &Path) -> Result<SenaConfig, ConfigError> {
+    if tokio::fs::metadata(path).await.is_ok() {
+        let contents = tokio::fs::read_to_string(path).await?;
+        let config: SenaConfig = toml::from_str(&contents)?;
+        Ok(config)
+    } else {
+        let config = SenaConfig::default();
+        save_config_at(&config, path).await?;
+        Ok(config)
+    }
+}
+
+async fn save_config_at(config: &SenaConfig, path: &Path) -> Result<(), ConfigError> {
     let toml_string = toml::to_string_pretty(config)?;
 
     if let Some(parent) = path.parent() {
@@ -104,14 +169,144 @@ pub async fn save_config(config: &SenaConfig) -> Result<(), ConfigError> {
     Ok(())
 }
 
+fn apply_config_value(config: &mut SenaConfig, key: &str, value: &str) -> Result<(), String> {
+    match key {
+        "file_watch_paths" => {
+            config.file_watch_paths = value
+                .split([';', ',', '\n'])
+                .map(str::trim)
+                .filter(|segment| !segment.is_empty())
+                .map(PathBuf::from)
+                .collect();
+        }
+        "clipboard_observation_enabled" => {
+            config.clipboard_observation_enabled = value
+                .parse::<bool>()
+                .map_err(|_| "expected true or false".to_string())?;
+        }
+        "speech_enabled" => {
+            config.speech_enabled = value
+                .parse::<bool>()
+                .map_err(|_| "expected true or false".to_string())?;
+        }
+        "inference_max_tokens" => {
+            config.inference_max_tokens = value
+                .parse::<usize>()
+                .map_err(|_| "expected a positive integer".to_string())?;
+        }
+        "auto_tune_tokens" => {
+            config.auto_tune_tokens = value
+                .parse::<bool>()
+                .map_err(|_| "expected true or false".to_string())?;
+        }
+        "auto_tune_min_tokens" => {
+            config.auto_tune_min_tokens = value
+                .parse::<usize>()
+                .map_err(|_| "expected a positive integer".to_string())?;
+        }
+        "auto_tune_max_tokens" => {
+            config.auto_tune_max_tokens = value
+                .parse::<usize>()
+                .map_err(|_| "expected a positive integer".to_string())?;
+        }
+        _ => {
+            return Err(format!(
+                "unknown key '{}'. Supported keys: clipboard_observation_enabled, speech_enabled, inference_max_tokens, auto_tune_tokens, auto_tune_min_tokens, auto_tune_max_tokens",
+                key
+            ));
+        }
+    }
+
+    if config.auto_tune_min_tokens > config.auto_tune_max_tokens {
+        return Err("auto_tune_min_tokens cannot exceed auto_tune_max_tokens".to_string());
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
-    #[tokio::test]
-    async fn config_loads_default() {
+    #[test]
+    fn default_config_has_expected_values() {
         let config = SenaConfig::default();
         assert!(config.file_watch_paths.is_empty());
         assert!(config.clipboard_observation_enabled);
+        assert!(config.speech_enabled);
+        assert_eq!(config.inference_max_tokens, 512);
+        assert!(config.auto_tune_tokens);
+        assert_eq!(config.auto_tune_min_tokens, 256);
+        assert_eq!(config.auto_tune_max_tokens, 4096);
+    }
+
+    #[tokio::test]
+    async fn load_or_create_config_creates_default_when_missing() {
+        let dir = tempdir().expect("failed to create tempdir");
+        let config_path = dir.path().join("config.toml");
+
+        let config = load_or_create_config_at(&config_path)
+            .await
+            .expect("load_or_create should succeed");
+
+        assert!(config_path.exists());
+        assert_eq!(config, SenaConfig::default());
+    }
+
+    #[tokio::test]
+    async fn load_or_create_config_loads_existing() {
+        let dir = tempdir().expect("failed to create tempdir");
+        let config_path = dir.path().join("config.toml");
+        let custom_config = SenaConfig {
+            clipboard_observation_enabled: false,
+            speech_enabled: false,
+            inference_max_tokens: 1024,
+            auto_tune_tokens: false,
+            auto_tune_min_tokens: 300,
+            auto_tune_max_tokens: 2048,
+            ..Default::default()
+        };
+        save_config_at(&custom_config, &config_path)
+            .await
+            .expect("save should succeed");
+
+        let loaded = load_or_create_config_at(&config_path)
+            .await
+            .expect("load should succeed");
+
+        assert_eq!(loaded, custom_config);
+    }
+
+    #[test]
+    fn apply_config_value_updates_scalar_fields() {
+        let mut config = SenaConfig::default();
+
+        apply_config_value(&mut config, "file_watch_paths", "C:/one;C:/two")
+            .expect("file_watch_paths should parse");
+        apply_config_value(&mut config, "speech_enabled", "false")
+            .expect("speech_enabled should parse");
+        apply_config_value(&mut config, "inference_max_tokens", "768")
+            .expect("inference_max_tokens should parse");
+        apply_config_value(&mut config, "auto_tune_tokens", "false")
+            .expect("auto_tune_tokens should parse");
+
+        assert_eq!(
+            config.file_watch_paths,
+            vec![PathBuf::from("C:/one"), PathBuf::from("C:/two")]
+        );
+        assert!(!config.speech_enabled);
+        assert_eq!(config.inference_max_tokens, 768);
+        assert!(!config.auto_tune_tokens);
+    }
+
+    #[test]
+    fn apply_config_value_rejects_invalid_auto_tune_range() {
+        let mut config = SenaConfig::default();
+        apply_config_value(&mut config, "auto_tune_max_tokens", "512")
+            .expect("auto_tune_max_tokens should parse");
+
+        let result = apply_config_value(&mut config, "auto_tune_min_tokens", "1024");
+        assert!(result.is_err());
     }
 }

--- a/sena/crates/runtime/src/lib.rs
+++ b/sena/crates/runtime/src/lib.rs
@@ -23,6 +23,8 @@
 //! Runtime depends on all other subsystem crates and constructs their concrete
 //! actor instances via builder functions.
 
+mod analytics;
+
 pub mod boot;
 pub mod builder;
 pub mod config;

--- a/sena/crates/runtime/src/supervisor.rs
+++ b/sena/crates/runtime/src/supervisor.rs
@@ -1,9 +1,10 @@
 //! Supervision loop — monitors actor liveness, handles readiness gate, emits BootComplete.
 
+use crate::analytics::TokenTuner;
 use crate::boot::BootResult;
 use crate::error::RuntimeError;
 use crate::health::ActorRegistry;
-use bus::{Event, SystemEvent};
+use bus::{Event, InferenceEvent, SystemEvent};
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
@@ -70,7 +71,8 @@ pub async fn supervision_loop(mut boot_result: BootResult) -> Result<(), Runtime
     );
 
     // Step 3: Main supervision loop
-    let shutdown_result = await_shutdown_or_health_checks(&boot_result, &mut actor_registry).await;
+    let shutdown_result =
+        await_shutdown_or_health_checks(&mut boot_result, &mut actor_registry).await;
 
     if let Err(e) = shutdown_result {
         warn!("SUPERVISOR: shutdown signal handling failed: {}", e);
@@ -166,12 +168,18 @@ async fn await_readiness_gate(
 /// This loop runs until a shutdown signal is received. Returns Ok(()) on clean
 /// shutdown signal, Err on channel failure.
 async fn await_shutdown_or_health_checks(
-    boot_result: &BootResult,
+    boot_result: &mut BootResult,
     actor_registry: &mut ActorRegistry,
 ) -> Result<(), RuntimeError> {
     info!("SUPERVISOR: entering main loop (awaiting shutdown or health checks)");
 
     let mut rx = boot_result.bus.subscribe_broadcast();
+    let mut token_tuner = TokenTuner::new(
+        boot_result.config.auto_tune_min_tokens,
+        boot_result.config.auto_tune_max_tokens,
+    );
+    let auto_tune_enabled = boot_result.config.auto_tune_tokens;
+    let mut current_max_tokens = boot_result.config.inference_max_tokens;
 
     loop {
         tokio::select! {
@@ -208,6 +216,36 @@ async fn await_shutdown_or_health_checks(
                         if expected_actor == actor.as_str() {
                             actor_registry.mark_failed(expected_actor, reason.clone());
                             break;
+                        }
+                    }
+                }
+                Ok(Event::Inference(InferenceEvent::InferenceCompleted { token_count, .. })) if auto_tune_enabled => {
+                    if let Some(recommendation) = token_tuner.record(token_count, current_max_tokens) {
+                        let old_max_tokens = current_max_tokens;
+                        boot_result.config.inference_max_tokens = recommendation.recommended_tokens;
+
+                        match crate::save_config(&boot_result.config).await {
+                            Ok(()) => {
+                                current_max_tokens = recommendation.recommended_tokens;
+                                info!(
+                                    old_max_tokens,
+                                    new_max_tokens = recommendation.recommended_tokens,
+                                    p95_tokens = recommendation.p95_tokens,
+                                    "SUPERVISOR: token budget auto-tuned"
+                                );
+                                let _ = boot_result
+                                    .bus
+                                    .broadcast(Event::System(SystemEvent::TokenBudgetAutoTuned {
+                                        old_max_tokens,
+                                        new_max_tokens: recommendation.recommended_tokens,
+                                        p95_tokens: recommendation.p95_tokens,
+                                    }))
+                                    .await;
+                            }
+                            Err(e) => {
+                                boot_result.config.inference_max_tokens = old_max_tokens;
+                                warn!(error = %e, "SUPERVISOR: failed to persist auto-tuned token budget");
+                            }
                         }
                     }
                 }
@@ -300,6 +338,7 @@ mod tests {
         let readiness_rx = bus.subscribe_broadcast();
         let boot_result = BootResult {
             bus,
+            config: crate::config::SenaConfig::default(),
             encryption: Arc::new(crypto::StubEncryptionLayer),
             actor_handles: vec![],
             expected_actors: vec![],
@@ -325,6 +364,7 @@ mod tests {
         let readiness_rx = bus.subscribe_broadcast();
         let mut boot_result = BootResult {
             bus,
+            config: crate::config::SenaConfig::default(),
             encryption: Arc::new(crypto::StubEncryptionLayer),
             actor_handles: vec![],
             expected_actors: vec![],
@@ -342,6 +382,7 @@ mod tests {
         let readiness_rx = bus.subscribe_broadcast();
         let _boot_result = BootResult {
             bus,
+            config: crate::config::SenaConfig::default(),
             encryption: Arc::new(crypto::StubEncryptionLayer),
             actor_handles: vec![],
             expected_actors: vec!["test_actor"],


### PR DESCRIPTION
Closes #89

## Summary
- thread persisted runtime config through boot and actor construction
- restore adaptive token budget tuning in the supervisor and inference actor
- expose runtime config get/set and forward token auto-tune events to IPC clients

## Validation
- rustfmt --check --edition 2024 crates/bus/src/events/system.rs crates/daemon/src/commands/config_commands.rs crates/daemon/src/main.rs crates/inference/src/actor.rs crates/platform/src/actor.rs crates/runtime/src/analytics.rs crates/runtime/src/boot.rs crates/runtime/src/builder.rs crates/runtime/src/config.rs crates/runtime/src/download_manager.rs crates/runtime/src/lib.rs crates/runtime/src/supervisor.rs
- cargo test -p bus -p inference -p platform -p runtime -p sena --quiet
- cargo clippy -p bus -p inference -p platform -p runtime -p sena -- -D warnings